### PR TITLE
Block Posts: Allow to select a post type

### DIFF
--- a/src/block/blog-posts/categories-list.js
+++ b/src/block/blog-posts/categories-list.js
@@ -1,0 +1,16 @@
+export default ( props ) => {
+	const { terms = [], separator = ', ' } = props;
+	if ( ! terms.length ) {
+		return null;
+	}
+
+	const parts = terms.map( term => {
+		return <a href={ term.term_link }>{term.name}</a>;
+	} );
+
+	return (
+		<div className="ugb-blog-posts__category-list" >
+			{ parts.reduce(( prev, curr ) => [ prev, separator, curr ] ) }
+		</div>
+	);
+}

--- a/src/block/blog-posts/category-select.js
+++ b/src/block/blog-posts/category-select.js
@@ -1,0 +1,51 @@
+import {
+	TreeSelect,
+} from '@wordpress/components';
+
+import { groupBy } from 'lodash';
+
+/**
+ * Returns terms in a tree form.
+ *
+ * @param {Array} flatTerms  Array of terms in flat format.
+ *
+ * @return {Array} Array of terms in tree format.
+ */
+export function buildTermsTree( flatTerms ) {
+	const flatTermsWithParentAndChildren = flatTerms.map( ( term ) => {
+		return {
+			children: [],
+			parent: null,
+			...term,
+		};
+	} );
+
+	const termsByParent = groupBy( flatTermsWithParentAndChildren, 'parent' );
+	if ( termsByParent.null && termsByParent.null.length ) {
+		return flatTermsWithParentAndChildren;
+	}
+	const fillWithChildren = ( terms ) => {
+		return terms.map( ( term ) => {
+			const children = termsByParent[ term.id ];
+			return {
+				...term,
+				children: children && children.length ?
+					fillWithChildren( children ) :
+					[],
+			};
+		} );
+	};
+
+	return fillWithChildren( termsByParent[ '0' ] || [] );
+}
+
+export default ( { label, noOptionLabel, categoriesList, selectedCategoryId, onChange } ) => {
+	const termsTree = buildTermsTree( categoriesList );
+	return (
+		<TreeSelect
+			{ ...{ label, noOptionLabel, onChange } }
+			tree={ termsTree }
+			selectedId={ selectedCategoryId }
+		/>
+	);
+}

--- a/src/block/blog-posts/index.php
+++ b/src/block/blog-posts/index.php
@@ -431,11 +431,11 @@ if ( ! function_exists( 'stackable_blog_posts_rest_fields' ) ) {
 		    // Category links.
 		    register_rest_field( $post_type, 'terms_list',
 			    array(
-				    'get_callback' => 'stackable_category_list',
+				    'get_callback' => 'stackable_terms_list',
 				    'update_callback' => null,
 				    'schema' => array(
-					    'description' => __( 'Category list links' ),
-					    'type' => 'string',
+					    'description' => __( 'Terms list links' ),
+					    'type' => 'array',
 				    ),
 			    )
 		    );
@@ -514,13 +514,13 @@ if ( ! function_exists( 'stackable_commments_number' ) ) {
     }
 }
 
-if ( ! function_exists( 'stackable_category_list' ) ) {
+if ( ! function_exists( 'stackable_terms_list' ) ) {
     /**
      * Get the category links.
      *
      * @since 1.7
      */
-    function stackable_category_list( $object ) {
+    function stackable_terms_list( $object ) {
     	$post = get_post( $object['id'] );
 	    $taxonomies = wp_list_filter( get_object_taxonomies( $post, 'objects' ), array( 'show_in_rest' => true ) );
 	    $data = [];


### PR DESCRIPTION
Hi.

This might be too much code for a PR coming from an unknown person :). I was trying to find some block plugin that could list posts with different layouts but that could also accept different types of post types. I came across with this plugin and it works great (nice work!) but I'm still missing that Post Type selector that could retrieve posts from another post type so here I am to try to solve this.

I tried also to create my own plugin but then I thought to create a PR against this one so it can be maintained by someone more focused on it.

The PR adds several changes to the Blog Post block:

- It fixes a nasty error that was totally stopping Gutenberg to work when the block is added for the first time in a post. This was due to `latestPosts` `null` value while Gutenberg fetches posts in the background. There are more extra checks now so this case is more unlikely to happen (or impossible).

- It adds a new Post Type selector which displays all the post types registered in WP that are public, have a REST Endpoint and are different from `attachment`.

![Captura de pantalla 2019-05-08 a las 16 37 51](https://user-images.githubusercontent.com/1516569/57383773-ae5c2280-71af-11e9-8899-5a94b0e07886.png)

- Expands the possibilities of filtering by taxonomies instead of just the category. There's a new `taxQuery` attribute that will handle all taxonomies selected.
![Captura de pantalla 2019-05-08 a las 16 38 44](https://user-images.githubusercontent.com/1516569/57383848-cdf34b00-71af-11e9-9478-32e2a665dcb0.png)

![Edit_Post_‹_WordPress_Multisite_—_WordPress](https://user-images.githubusercontent.com/1516569/57383966-02ff9d80-71b0-11e9-995f-1b5a87cc1687.png)

These taxonomies are only those that are hierarchical (So I'm excluding tags), public and have a REST endpoint.

- Instead of a `Display Category` switch, I replaced it for a selector where the user can select what taxonomy to display above every post. Although can be a bit confusing for some users that don't understand what a taxonomy is, I think it made sense to display it this way.

![Edit_Post_‹_WordPress_Multisite_—_WordPress](https://user-images.githubusercontent.com/1516569/57384259-8de09800-71b0-11e9-9e7a-864aa3d5424c.png)

- The plugin is now exposing REST fields for every post type and I replaced `category_list` REST field for a `terms_list` instead, which makes more sense now but I had to rework it as it was returning HTML while I needed to return a list of terms grouped by taxonomy. The HTML is not inserted "Dangerously" now but it could cause some markup differences in some themes. This could be considered to merge this PR I guess.

- The PR takes care of backwards compatibiility: If the user already had the category displaying, this will be still checked.

Thanks!

