### PR TITLE
Add support for EditorsKit navigator toolbar

### DIFF
--- a/src/block/container/index.js
+++ b/src/block/container/index.js
@@ -106,6 +106,8 @@ export const settings = {
 	supports: {
 		align: [ 'center', 'wide', 'full' ],
 		inserter: ! disabledBlocks.includes( name ), // Hide if disabled.
+		// Add EditorsKit block navigator toolbar
+		editorsKitBlockNavigator: true,
 	},
 	attributes: schema,
 }


### PR DESCRIPTION
Hi,

I've just recently added Block Navigation toolbar on my EditorsKit plugin. I think this will be of great help on user navigation when both plugins are activated. The toolbar will only be shown on blocks with multiple inner blocks capability.

- [x] Container

![Screen Capture on 2019-10-10 at 16-45-11](https://user-images.githubusercontent.com/3365507/66553567-f4ae1700-eb7d-11e9-9293-6bdf3e91ad07.gif)

Let me know your thoughts.

Thanks,
Jeffrey
