### PR TITLE
[block-container] Fixes child block toolbar being cut off. Closes #502

### DIFF
--- a/src/block/container/editor.scss
+++ b/src/block/container/editor.scss
@@ -51,3 +51,17 @@
 .ugb-container .wp-block-columns .editor-inner-blocks {
 	width: 100%;
 }
+
+// Containers have overflow and cut off the block editor's controls (toolbar and drag handles).
+// Make overflow visible, but also do some tweaks so that the background gradients & videos
+// Still follow the border radius of the Container block.
+.ugb-container > .ugb-inner-block > .ugb-block-content > .ugb-container__wrapper {
+	overflow: visible;
+	> .ugb-video-background {
+		overflow: hidden;
+	}
+	&::before {
+		// Add transition since our pseudo element doesn't have it and it looks bad.
+		transition: border-radius 0.2s ease-in-out;
+	}
+}

--- a/src/block/container/style.js
+++ b/src/block/container/style.js
@@ -30,6 +30,14 @@ export const createStyles = props => {
 			[ `.${ uniqueClass }-wrapper.ugb-container__wrapper` ]: {
 				borderRadius: getValue( 'borderRadius', '%spx !important' ),
 			},
+			// Block editor only styles. This is needed since in the editor, we don't hide overflow
+			// so that the block controls wouldn't be cut off from view.
+			editor: {
+				[ `.${ uniqueClass }-wrapper.ugb-container__wrapper > .ugb-video-background, ` +
+				  `.${ uniqueClass }-wrapper.ugb-container__wrapper:before` ]: {
+					borderRadius: getValue( 'borderRadius', '%spx !important' ) || '12px !important',
+				},
+			},
 		} )
 	}
 


### PR DESCRIPTION
[block-container] Fixes child block toolbar being cut off. Closes #502