### PR TITLE
Google fonts not working in some race hook conditions.

### DIFF
--- a/src/fonts.php
+++ b/src/fonts.php
@@ -12,7 +12,7 @@ if ( ! class_exists( 'Stackable_Google_Fonts' ) ) {
     class Stackable_Google_Fonts {
 
         function __construct() {
-            add_action( 'wp_head', array( $this, 'enqueue_frontend_block_fonts' ), 100 );
+            add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_block_fonts' ), 100 );
 		}
 
 		public function enqueue_frontend_block_fonts() {


### PR DESCRIPTION
Solves an issue where on certain post types, the wp_head hook has already fired. Solve this by hooking to wp_enqueue_scripts which will always run before wp_head, allowing wp_enqueue_style() to always fire properly.