### PR TITLE
fix (toolbar): fix icon size (alignment, padding) and fix background …

### DIFF
--- a/src/components/advanced-toolbar-control/editor.scss
+++ b/src/components/advanced-toolbar-control/editor.scss
@@ -45,12 +45,19 @@
 				box-shadow: inset 0 0 0 1px #555d66, inset 0 0 0 2px #fff;
 			}
 		}
-		&.is-active {
+		&.is-active,
+		&.is-pressed {
 			.ugb-advanced-toolbar-control__text-button {
 				outline: none;
 				color: #fff;
 				box-shadow: none;
 				background: #555d66;
+			}
+		}
+		&.has-icon {
+			padding: 3px;
+			> svg {
+				padding: 5px;
 			}
 		}
 	}

--- a/src/components/four-range-control/editor.scss
+++ b/src/components/four-range-control/editor.scss
@@ -18,8 +18,13 @@
 }
 .ugb-four-range-control {
 	.ugb-four-range-control__lock {
+		height: auto;
 		color: #555d66;
 		box-shadow: none !important;
 		margin-left: 5px;
+		svg {
+			height: 16px;
+			width: 16px;
+		}
 	}
 }


### PR DESCRIPTION
…color for active buttons with labels only (background color type). (WordPress 5.4) Closes #647