### PR TITLE
fix (button): Adjust button size when its icon is resized. (WordPress…

### DIFF
--- a/src/components/button-edit/editor.scss
+++ b/src/components/button-edit/editor.scss
@@ -6,3 +6,7 @@
 .ugb-button.ugb-button--icon-only .ugb-svg-icon-placeholder__button {
 	display: block;
 }
+// Resize the button when its icon is resized
+.ugb-button.ugb-button--has-icon .ugb-svg-icon-placeholder__button {
+	height: auto;
+}


### PR DESCRIPTION
… 5.4) Closes #658