### PR TITLE
fix($util): make hexToRgba recognize CSS custom properties

### DIFF
--- a/src/util/__test__/index.test.js
+++ b/src/util/__test__/index.test.js
@@ -17,6 +17,10 @@ describe( 'hexToRgba', () => {
 		expect( hexToRgba( '#ab5af1' ) ).toBe( 'rgba(171, 90, 241, 1)' )
 		expect( hexToRgba( '#ab5af1', 0.4 ) ).toBe( 'rgba(171, 90, 241, 0.4)' )
 	} )
+
+	it( 'defaults to white when variable is missing', () => {
+		expect( hexToRgba( 'var(--color)', 1 ) ).toBe( 'rgba(255, 255, 255, 1)' )
+	} )
 } )
 
 describe( 'prependCSSClass', () => {

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -131,9 +131,9 @@ export const hexToRgba = ( hexColor, opacity = null ) => {
 	 * Detect CSS variables in form of var(--color) and get their current
 	 * values from the :root selector.
 	 */
-	if ( hexColor.indexOf( 'var(' ) > -1 && isEditor() ) {
+	if ( hexColor.indexOf( 'var(' ) > -1 ) {
 		hexColor = window.getComputedStyle( document.documentElement )
-			.getPropertyValue( hexColor.replace( 'var(', '' ).replace( ')', '' ) )
+			.getPropertyValue( hexColor.replace( 'var(', '' ).replace( ')', '' ) ) || '#fff'
 	}
 
 	hex = hexColor.replace( /#/, '' )

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -125,7 +125,19 @@ export const descriptionPlaceholder = length => {
  * @return {string} Rgba color.
  */
 export const hexToRgba = ( hexColor, opacity = null ) => {
-	let hex = hexColor.replace( /#/, '' )
+	let hex = null
+
+	/**
+	 * Detect CSS variables in form of var(--color) and get their current
+	 * values from the :root selector.
+	 */
+	if ( hexColor.indexOf( 'var(' ) > -1 && isEditor() ) {
+		hexColor = window.getComputedStyle( document.documentElement )
+			.getPropertyValue( hexColor.replace( 'var(', '' ).replace( ')', '' ) )
+	}
+
+	hex = hexColor.replace( /#/, '' )
+
 	if ( hex.length <= 4 ) {
 		hex = hex.replace( /#?(.)(.)(.)/, '$1$1$2$2$3$3' )
 	}


### PR DESCRIPTION
Solves the problem of applying the opacity onto the colors from the Gutenberg color palette, when the color palette contains a CSS Custom Property. It expects the css variable to be defined on the `:root` element.

How to test:

Apply this palette to Gutenberg:

```php
add_theme_support( 'editor-color-palette', [
    [
        'name' => __( 'Palette Color 1', 'blocksy' ),
        'slug' => 'palette-color-1',
        'color' => 'var(--paletteColor1)',
    ],

    [
        'name' => __( 'Palette Color 2', 'blocksy' ),
        'slug' => 'palette-color-2',
        'color' => 'var(--paletteColor2)',
    ],

    [
        'name' => __( 'Palette Color 3', 'blocksy' ),
        'slug' => 'palette-color-3',
        'color' => 'var(--paletteColor3)',
    ],

    [
        'name' => __( 'Palette Color 4', 'blocksy' ),
        'slug' => 'palette-color-4',
        'color' => 'var(--paletteColor4)',
    ],

    [
        'name' => __( 'Palette Color 5', 'blocksy' ),
        'slug' => 'palette-color-5',
        'color' => 'var(--paletteColor5)',
    ]
]);
```

With that in place, define these CSS variables from:

```css
:root {
  --paletteColor1: red;
  --paletteColor2: green;
  --paletteColor3: blue;
  --paletteColor4: pink;
  --paletteColor5: black;
}
```

With this in place, `hexToRgba()` will be able to apply the opacity correctly. I'll be happy to change the implementation if this somehow doesn't fit the project's guidelines and rules.

---

This approach for the Color Palette is used in [Blocksy](https://wordpress.org/themes/blocksy/) and there were no problems with this up until now. Hope this fix could be included in Stackable for a better compatibility between the two tools.