### PR TITLE
Fixes #1033

### DIFF
--- a/src/plugins/auto-block-recovery/is-invalid.js
+++ b/src/plugins/auto-block-recovery/is-invalid.js
@@ -11,11 +11,16 @@ const ALLOWED_ERROR_TAGS = [ 'style', 'svg' ]
 
 export const isInvalid = ( block, allowedTags = ALLOWED_ERROR_TAGS ) => {
 	const {
-		name, isValid, validationIssues,
+		name, isValid, validationIssues, originalContent,
 	} = block
 
 	// Only do this for Stackable blocks.
 	if ( ! name || ! name.match( /^ugb\// ) ) {
+		return false
+	}
+
+	// Only do this for blocks with .ugb-main-block
+	if ( ! originalContent.match( /ugb-main-block/ ) ) {
 		return false
 	}
 

--- a/src/plugins/auto-block-recovery/is-invalid.js
+++ b/src/plugins/auto-block-recovery/is-invalid.js
@@ -19,8 +19,8 @@ export const isInvalid = ( block, allowedTags = ALLOWED_ERROR_TAGS ) => {
 		return false
 	}
 
-	// Only do this for blocks with .ugb-main-block
-	if ( ! originalContent.match( /ugb-main-block/ ) ) {
+	// Only do this for blocks with .ugb-main-block and not separator block.
+	if ( ! name.match( /separator/ ) && ! originalContent.match( /ugb-main-block/ ) ) {
 		return false
 	}
 


### PR DESCRIPTION
fixes #1033

Note: v2 Separator blocks don't have `ugb-main-block` class