### PR TITLE
Fixes Global Color Palette

### DIFF
--- a/src/plugins/global-settings/colors/color-palette-updater.js
+++ b/src/plugins/global-settings/colors/color-palette-updater.js
@@ -53,10 +53,7 @@ const GlobalColorPaletteUpdater = () => {
 				 *
 				 * @since v2.7.2
 				 */
-				...(
-					useStackableColorsOnly ?
-						{ __experimentalFeatures: { colors: { palette: { theme: [ ...defaultColors ] } } } } : {}
-				),
+				__experimentalFeatures: { colors: { palette: { theme: [ ...newColors ] } } },
 			} )
 		}
 	}, [ JSON.stringify( colors ), JSON.stringify( defaultColors ), JSON.stringify( stackableColors ), useStackableColorsOnly, isInitializing ] )


### PR DESCRIPTION
Fixes an issue where the global colors don't update when `useStackableColorsOnly` is disabled.