### PR TITLE
Fix: Column widths x column gap in tablet and mobile

### DIFF
--- a/src/block-components/advanced/style.js
+++ b/src/block-components/advanced/style.js
@@ -94,7 +94,7 @@ const getStyleParams = ( options = {} ) => {
 		// We need to implement z-index on the block itself or else it won't look correct in the editor.
 		{
 			renderIn: 'edit',
-			selectorCallback: getAttribute => `.wp-block[data-block="${ getAttribute( 'clientId' ) }"]`,
+			selectorCallback: getAttribute => `.editor-styles-wrapper [data-block="${ getAttribute( 'clientId' ) }"]`,
 			styleRule: 'zIndex',
 			attrName: 'zIndex',
 			responsive: 'all',

--- a/src/block-components/advanced/style.js
+++ b/src/block-components/advanced/style.js
@@ -94,7 +94,7 @@ const getStyleParams = ( options = {} ) => {
 		// We need to implement z-index on the block itself or else it won't look correct in the editor.
 		{
 			renderIn: 'edit',
-			selectorCallback: getAttribute => `[data-block="${ getAttribute( 'clientId' ) }"]`,
+			selectorCallback: getAttribute => `.wp-block[data-block="${ getAttribute( 'clientId' ) }"]`,
 			styleRule: 'zIndex',
 			attrName: 'zIndex',
 			responsive: 'all',

--- a/src/block-components/column/attributes.js
+++ b/src/block-components/column/attributes.js
@@ -6,6 +6,12 @@ export const addAttributes = attrObject => {
 				type: 'number',
 				default: '',
 			},
+			// This is used to set the amount of column gap to compute for flex basis.
+			columnAdjacentCount: {
+				stkResponsive: true,
+				type: 'number',
+				default: '',
+			},
 		},
 		versionAdded: '3.0.0',
 		versionDeprecated: '',

--- a/src/block-components/column/style.js
+++ b/src/block-components/column/style.js
@@ -14,7 +14,7 @@ const getStyleParams = ( options = {} ) => {
 	return [
 		{
 			renderIn: 'edit',
-			selectorCallback: getAttribute => `[data-block="${ getAttribute( 'clientId' ) }"]`,
+			selectorCallback: getAttribute => `.wp-block[data-block="${ getAttribute( 'clientId' ) }"]`,
 			styleRule: 'flex',
 			attrName: 'columnWidth',
 			responsive: [ 'desktopTablet', 'tabletOnly', 'mobile' ],
@@ -36,7 +36,7 @@ const getStyleParams = ( options = {} ) => {
 		// resizes to a larger size.
 		{
 			renderIn: 'edit',
-			selectorCallback: getAttribute => `[data-block="${ getAttribute( 'clientId' ) }"]`,
+			selectorCallback: getAttribute => `.wp-block[data-block="${ getAttribute( 'clientId' ) }"]`,
 			styleRule: 'maxWidth',
 			attrName: 'columnWidth',
 			responsive: [ 'desktopTablet', 'tabletOnly', 'mobile' ],

--- a/src/block-components/column/style.js
+++ b/src/block-components/column/style.js
@@ -2,12 +2,82 @@
  * External dependencies
  */
 import {
-	__getValue,
+	__getValue, useStyles, getStyles,
 } from '~stackable/util'
 import { Style as StyleComponent } from '~stackable/components'
-import { useMemo } from '@wordpress/element'
 
-const getStyles = ( attributes, options = {} ) => {
+const getStyleParams = ( options = {} ) => {
+	const {
+		selector = '',
+	} = options
+
+	return [
+		{
+			renderIn: 'edit',
+			selectorCallback: getAttribute => `[data-block="${ getAttribute( 'clientId' ) }"]`,
+			styleRule: 'flex',
+			attrName: 'columnWidth',
+			responsive: [ 'desktopTablet', 'tabletOnly', 'mobile' ],
+			// format: '0 1 calc(%s% - var(--stk-column-gap, 0px))',
+			format: '0 1 %s%',
+			dependencies: [ 'columnAdjacentCount' ],
+			valueCallback: ( value, getAttribute, device ) => {
+				if ( device === 'desktop' ) {
+					return value
+				}
+				const adjacentCount = getAttribute( 'columnAdjacentCount', device )
+				if ( adjacentCount ) {
+					return value.replace( /([\d\.]+%)$/, `calc($1 - var(--stk-column-gap, 0px) * ${ adjacentCount - 1 } / ${ adjacentCount } )` )
+				}
+				return value
+			},
+		},
+		// We need to add a maxWidth in the editor since the re-resizable box
+		// can mess up the snapping if the column width is too small, then
+		// resizes to a larger size.
+		{
+			renderIn: 'edit',
+			selectorCallback: getAttribute => `[data-block="${ getAttribute( 'clientId' ) }"]`,
+			styleRule: 'maxWidth',
+			attrName: 'columnWidth',
+			responsive: [ 'desktopTablet', 'tabletOnly', 'mobile' ],
+			format: '%s%',
+			dependencies: [ 'columnAdjacentCount' ],
+			valueCallback: ( value, getAttribute, device ) => {
+				if ( device === 'desktop' ) {
+					return value
+				}
+				const adjacentCount = getAttribute( 'columnAdjacentCount', device )
+				if ( adjacentCount ) {
+					return value.replace( /([\d\.]+%)$/, `calc($1 - var(--stk-column-gap, 0px) * ${ adjacentCount - 1 } / ${ adjacentCount } )` )
+				}
+				return value
+			},
+		},
+		{
+			renderIn: 'save',
+			selector,
+			styleRule: 'flex',
+			attrName: 'columnWidth',
+			responsive: [ 'desktopTablet', 'tabletOnly', 'mobile' ],
+			format: '0 1 %s%',
+			dependencies: [ 'columnAdjacentCount' ],
+			valueCallback: ( value, getAttribute, device ) => {
+				if ( device === 'desktop' ) {
+					return value
+				}
+
+				const adjacentCount = getAttribute( 'columnAdjacentCount', device )
+				if ( adjacentCount ) {
+					return value.replace( /([\d\.]+%)$/, `calc($1 - var(--stk-column-gap, 0px) * ${ adjacentCount - 1 } / ${ adjacentCount } )` )
+				}
+				return value
+			},
+		},
+	]
+}
+
+const _getStyles = ( attributes, options = {} ) => {
 	const {
 		selector = '',
 	} = options
@@ -18,36 +88,36 @@ const getStyles = ( attributes, options = {} ) => {
 			custom: {
 				[ `.stk-preview-device-desktop :where(.block-editor-block-list__layout) [data-block="${ attributes.clientId }"],
 				.stk-preview-device-tablet :where(.block-editor-block-list__layout) [data-block="${ attributes.clientId }"]` ]: {
-					flex: getValue( 'columnWidth', '1 1 %s%' ),
-					maxWidth: getValue( 'columnWidth', '%s%' ),
+					flex: getValue( 'columnWidth', '0 1 calc(%s% - var(--stk-column-gap, 0px))' ),
+					// maxWidth: getValue( 'columnWidth', '%s%' ),
 				},
 				[ `.stk-preview-device-tablet :where(.block-editor-block-list__layout) [data-block="${ attributes.clientId }"]` ]: {
-					flex: getValue( 'columnWidthTablet', '1 1 %s%' ),
-					maxWidth: getValue( 'columnWidthTablet', '%s%' ),
+					flex: getValue( 'columnWidthTablet', '0 1 calc(%s% - var(--stk-column-gap, 0px))' ),
+					// maxWidth: getValue( 'columnWidthTablet', '%s%' ),
 				},
 				[ `.stk-preview-device-mobile :where(.block-editor-block-list__layout) [data-block="${ attributes.clientId }"]` ]: {
-					flex: getValue( 'columnWidthMobile', '1 1 %s%' ),
-					maxWidth: getValue( 'columnWidthMobile', '%s%' ),
+					flex: getValue( 'columnWidthMobile', '0 1 calc(%s% - var(--stk-column-gap, 0px))' ),
+					// maxWidth: getValue( 'columnWidthMobile', '%s%' ),
 				},
 			},
 		},
 		saveOnly: {
 			desktopTablet: {
 				[ selector ]: {
-					flex: getValue( 'columnWidth', '1 1 %s%' ),
-					maxWidth: getValue( 'columnWidth', '%s%' ),
+					flex: getValue( 'columnWidth', '0 1 calc(%s% - var(--stk-column-gap, 0px))' ),
+					// maxWidth: getValue( 'columnWidth', '%s%' ),
 				},
 			},
 			tabletOnly: {
 				[ selector ]: {
-					flex: getValue( 'columnWidthTablet', '1 1 %s%' ),
-					maxWidth: getValue( 'columnWidthTablet', '%s%' ),
+					flex: getValue( 'columnWidthTablet', '0 1 calc(%s% - var(--stk-column-gap, 0px))' ),
+					// maxWidth: getValue( 'columnWidthTablet', '%s%' ),
 				},
 			},
 			mobile: {
 				[ selector ]: {
-					flex: getValue( 'columnWidthMobile', '1 1 %s%' ),
-					maxWidth: getValue( 'columnWidthMobile', '%s%' ),
+					flex: getValue( 'columnWidthMobile', '0 1 calc(%s% - var(--stk-column-gap, 0px))' ),
+					// maxWidth: getValue( 'columnWidthMobile', '%s%' ),
 				},
 			},
 		},
@@ -57,16 +127,10 @@ const getStyles = ( attributes, options = {} ) => {
 export const Style = props => {
 	const {
 		attributes,
-		options = {},
 		...propsToPass
 	} = props
 
-	const getValue = __getValue( attributes )
-
-	const styles = useMemo(
-		() => getStyles( attributes, options ),
-		[ getValue( 'columnWidth' ), getValue( 'columnWidthTablet' ), getValue( 'columnWidthMobile' ), attributes.clientId ]
-	)
+	const styles = useStyles( attributes, getStyleParams() )
 
 	return (
 		<StyleComponent
@@ -80,12 +144,14 @@ export const Style = props => {
 
 Style.Content = props => {
 	const {
-		attributes,
-		options = {},
 		...propsToPass
 	} = props
 
-	const styles = getStyles( attributes, options )
+	if ( props.attributes.generatedCss ) {
+		return <style>{ props.attributes.generatedCss }</style>
+	}
+
+	const styles = getStyles( propsToPass.attributes, getStyleParams() )
 
 	return (
 		<StyleComponent.Content

--- a/src/block-components/column/style.js
+++ b/src/block-components/column/style.js
@@ -18,8 +18,7 @@ const getStyleParams = ( options = {} ) => {
 			styleRule: 'flex',
 			attrName: 'columnWidth',
 			responsive: [ 'desktopTablet', 'tabletOnly', 'mobile' ],
-			// format: '0 1 calc(%s% - var(--stk-column-gap, 0px))',
-			format: '0 1 %s%',
+			format: '1 1 %s%',
 			dependencies: [ 'columnAdjacentCount' ],
 			valueCallback: ( value, getAttribute, device ) => {
 				if ( device === 'desktop' ) {
@@ -60,9 +59,20 @@ const getStyleParams = ( options = {} ) => {
 			styleRule: 'flex',
 			attrName: 'columnWidth',
 			responsive: [ 'desktopTablet', 'tabletOnly', 'mobile' ],
-			format: '0 1 %s%',
+			format: '1 1 %s%',
 			dependencies: [ 'columnAdjacentCount' ],
-			valueCallback: ( value, getAttribute, device ) => {
+			valueCallback: ( _value, getAttribute, device ) => {
+				// Flex grow should be turned on in desktop, so negative margins
+				// can make the columns expand. (e.g. 50% 50% then -200px margin
+				// left on 2nd column).
+				//
+				// In tablet/mobile, don't allow expanding since columns would
+				// always expand to the available space (so you can't do a 30%
+				// 30% columns in tablet/mobile, they will expand to 50% 50%)
+				//
+				// No need to do this in the editor since it already does this.
+				const value = device === 'desktop' ? _value : _value.replace( /^1 1/, '0 1' )
+
 				if ( device === 'desktop' ) {
 					return value
 				}
@@ -75,53 +85,6 @@ const getStyleParams = ( options = {} ) => {
 			},
 		},
 	]
-}
-
-const _getStyles = ( attributes, options = {} ) => {
-	const {
-		selector = '',
-	} = options
-	const getValue = __getValue( attributes )
-
-	return {
-		editor: {
-			custom: {
-				[ `.stk-preview-device-desktop :where(.block-editor-block-list__layout) [data-block="${ attributes.clientId }"],
-				.stk-preview-device-tablet :where(.block-editor-block-list__layout) [data-block="${ attributes.clientId }"]` ]: {
-					flex: getValue( 'columnWidth', '0 1 calc(%s% - var(--stk-column-gap, 0px))' ),
-					// maxWidth: getValue( 'columnWidth', '%s%' ),
-				},
-				[ `.stk-preview-device-tablet :where(.block-editor-block-list__layout) [data-block="${ attributes.clientId }"]` ]: {
-					flex: getValue( 'columnWidthTablet', '0 1 calc(%s% - var(--stk-column-gap, 0px))' ),
-					// maxWidth: getValue( 'columnWidthTablet', '%s%' ),
-				},
-				[ `.stk-preview-device-mobile :where(.block-editor-block-list__layout) [data-block="${ attributes.clientId }"]` ]: {
-					flex: getValue( 'columnWidthMobile', '0 1 calc(%s% - var(--stk-column-gap, 0px))' ),
-					// maxWidth: getValue( 'columnWidthMobile', '%s%' ),
-				},
-			},
-		},
-		saveOnly: {
-			desktopTablet: {
-				[ selector ]: {
-					flex: getValue( 'columnWidth', '0 1 calc(%s% - var(--stk-column-gap, 0px))' ),
-					// maxWidth: getValue( 'columnWidth', '%s%' ),
-				},
-			},
-			tabletOnly: {
-				[ selector ]: {
-					flex: getValue( 'columnWidthTablet', '0 1 calc(%s% - var(--stk-column-gap, 0px))' ),
-					// maxWidth: getValue( 'columnWidthTablet', '%s%' ),
-				},
-			},
-			mobile: {
-				[ selector ]: {
-					flex: getValue( 'columnWidthMobile', '0 1 calc(%s% - var(--stk-column-gap, 0px))' ),
-					// maxWidth: getValue( 'columnWidthMobile', '%s%' ),
-				},
-			},
-		},
-	}
 }
 
 export const Style = props => {

--- a/src/block-components/column/style.js
+++ b/src/block-components/column/style.js
@@ -14,7 +14,7 @@ const getStyleParams = ( options = {} ) => {
 	return [
 		{
 			renderIn: 'edit',
-			selectorCallback: getAttribute => `.wp-block[data-block="${ getAttribute( 'clientId' ) }"]`,
+			selectorCallback: getAttribute => `.editor-styles-wrapper [data-block="${ getAttribute( 'clientId' ) }"]`,
 			styleRule: 'flex',
 			attrName: 'columnWidth',
 			responsive: [ 'desktopTablet', 'tabletOnly', 'mobile' ],
@@ -36,7 +36,7 @@ const getStyleParams = ( options = {} ) => {
 		// resizes to a larger size.
 		{
 			renderIn: 'edit',
-			selectorCallback: getAttribute => `.wp-block[data-block="${ getAttribute( 'clientId' ) }"]`,
+			selectorCallback: getAttribute => `.editor-styles-wrapper [data-block="${ getAttribute( 'clientId' ) }"]`,
 			styleRule: 'maxWidth',
 			attrName: 'columnWidth',
 			responsive: [ 'desktopTablet', 'tabletOnly', 'mobile' ],

--- a/src/block-components/column/use-column.js
+++ b/src/block-components/column/use-column.js
@@ -7,6 +7,7 @@ import { useDispatch, select } from '@wordpress/data'
 import { useCallback } from '@wordpress/element'
 import { useBlockEditContext } from '@wordpress/block-editor'
 import classnames from 'classnames'
+import { getRowsFromColumns } from './util'
 
 export const useColumn = () => {
 	const { clientId } = useBlockEditContext()
@@ -28,15 +29,45 @@ export const useColumn = () => {
 	)
 
 	const onChangeTablet = useCallback(
-		width => {
+		( width, widths ) => {
 			updateBlockAttributes( clientId, { columnWidthTablet: width } )
+
+			const parentClientId = last( select( 'core/block-editor' ).getBlockParents( clientId ) )
+			const adjacentBlocks = select( 'core/block-editor' ).getBlock( parentClientId )?.innerBlocks || []
+
+			if ( adjacentBlocks.length ) {
+				const columnRows = getRowsFromColumns( widths )
+
+				widths.forEach( ( width, i ) => {
+					// TODO: When Gutenberg 10.1 comes out, update this to just one updateBlockAttributes call for all client Ids
+					updateBlockAttributes( adjacentBlocks[ i ].clientId, {
+						columnWidthTablet: widths[ i ],
+						columnAdjacentCountTablet: columnRows.filter( n => n === columnRows[ i ] ).length,
+					} )
+				} )
+			}
 		},
 		[ clientId, updateBlockAttributes ]
 	)
 
 	const onChangeMobile = useCallback(
-		width => {
+		( width, widths ) => {
 			updateBlockAttributes( clientId, { columnWidthMobile: width } )
+
+			const parentClientId = last( select( 'core/block-editor' ).getBlockParents( clientId ) )
+			const adjacentBlocks = select( 'core/block-editor' ).getBlock( parentClientId )?.innerBlocks || []
+
+			if ( adjacentBlocks.length ) {
+				const columnRows = getRowsFromColumns( widths )
+
+				widths.forEach( ( width, i ) => {
+					// TODO: When Gutenberg 10.1 comes out, update this to just one updateBlockAttributes call for all client Ids
+					updateBlockAttributes( adjacentBlocks[ i ].clientId, {
+						columnWidthMobile: widths[ i ],
+						columnAdjacentCountMobile: columnRows.filter( n => n === columnRows[ i ] ).length,
+					} )
+				} )
+			}
 		},
 		[ clientId, updateBlockAttributes ]
 	)

--- a/src/block-components/column/util.js
+++ b/src/block-components/column/util.js
@@ -1,0 +1,28 @@
+import { sum } from 'lodash'
+
+/**
+ * Gets the row of each column based on their width values. When the width
+ * values surpass 100, then the next column collapses down. e.g. [ 30, 40, 50 ]
+ * returns [ 1, 1, 2 ], which means:
+ * - The 1st column is on the 1st row
+ * - The 2nd column is on the 1st row
+ * - The 3rd column is on the 2nd row
+ *
+ * @param {Array} widths Array of width values, e.g. [ 33.33, 33.33, 33.33 ]
+ * @return {Array} An array containing the row number of each column.
+ */
+export const getRowsFromColumns = widths => {
+	const columnRows = []
+	widths.reduce( ( columnCounts, width ) => {
+		const lastTotalWidth = sum( columnCounts[ columnCounts.length - 1 ] )
+		if ( lastTotalWidth + width > 100 ) {
+			columnCounts.push( [ width ] )
+		} else {
+			columnCounts[ columnCounts.length - 1 ].push( width )
+		}
+		columnRows.push( columnCounts.length )
+		return columnCounts
+	}, [ [] ] )
+
+	return columnRows
+}

--- a/src/block-components/content-align/attributes.js
+++ b/src/block-components/content-align/attributes.js
@@ -15,6 +15,11 @@ export const addAttributes = attrObject => {
 				type: 'number',
 				default: '',
 			},
+			rowGap: {
+				stkResponsive: true,
+				type: 'number',
+				default: '',
+			},
 			innerBlockContentAlign: {
 				type: 'string',
 				default: '',

--- a/src/block-components/content-align/edit.js
+++ b/src/block-components/content-align/edit.js
@@ -102,6 +102,14 @@ export const Controls = props => {
 						sliderMax={ 100 }
 						placeholder="0"
 					/>
+					<AdvancedRangeControl
+						label={ __( 'Row Gap', i18n ) }
+						attribute="rowGap"
+						responsive="all"
+						min={ 0 }
+						sliderMax={ 100 }
+						placeholder="0"
+					/>
 				</>
 			) }
 

--- a/src/block-components/content-align/style.js
+++ b/src/block-components/content-align/style.js
@@ -28,6 +28,22 @@ const getStyleParams = () => {
 		{
 			renderIn: 'save',
 			selector: '.%s-column',
+			styleRule: 'rowGap',
+			attrName: 'rowGap',
+			format: '%spx',
+			responsive: 'all',
+		},
+		{
+			renderIn: 'edit',
+			selector: '.%s-column > .block-editor-inner-blocks > .block-editor-block-list__layout',
+			styleRule: 'rowGap',
+			attrName: 'rowGap',
+			format: '%spx',
+			responsive: 'all',
+		},
+		{
+			renderIn: 'save',
+			selector: '.%s-column',
 			styleRule: 'justifyContent',
 			attrName: 'columnFitAlign',
 			responsive: 'all',

--- a/src/block-components/content-align/style.js
+++ b/src/block-components/content-align/style.js
@@ -12,7 +12,7 @@ const getStyleParams = () => {
 		{
 			renderIn: 'save',
 			selector: '.%s-column',
-			styleRule: 'columnGap',
+			styleRule: '--stk-column-gap',
 			attrName: 'columnGap',
 			format: '%spx',
 			responsive: 'all',
@@ -20,7 +20,7 @@ const getStyleParams = () => {
 		{
 			renderIn: 'edit',
 			selector: '.%s-column > .block-editor-inner-blocks > .block-editor-block-list__layout',
-			styleRule: 'columnGap',
+			styleRule: '--stk-column-gap',
 			attrName: 'columnGap',
 			format: '%spx',
 			responsive: 'all',

--- a/src/block/column/style.js
+++ b/src/block/column/style.js
@@ -88,7 +88,7 @@ const BlockStyles = props => {
 	return (
 		<Fragment>
 			<Alignment.Style { ...propsToPass } options={ {
-				columnAlignSelectorCallback: getAttribute => `.wp-block[data-block="${ getAttribute( 'clientId' ) }"]`,
+				columnAlignSelectorCallback: getAttribute => `.editor-styles-wrapper [data-block="${ getAttribute( 'clientId' ) }"]`,
 			} } />
 			<BlockDiv.Style { ...propsToPass } />
 			<Column.Style { ...propsToPass } />

--- a/src/block/column/style.js
+++ b/src/block/column/style.js
@@ -88,7 +88,7 @@ const BlockStyles = props => {
 	return (
 		<Fragment>
 			<Alignment.Style { ...propsToPass } options={ {
-				columnAlignSelectorCallback: getAttribute => `[data-block="${ getAttribute( 'clientId' ) }"]`,
+				columnAlignSelectorCallback: getAttribute => `.wp-block[data-block="${ getAttribute( 'clientId' ) }"]`,
 			} } />
 			<BlockDiv.Style { ...propsToPass } />
 			<Column.Style { ...propsToPass } />

--- a/src/block/columns/editor.scss
+++ b/src/block/columns/editor.scss
@@ -24,3 +24,7 @@
 	min-width: 24px;
 	max-width: none;
 }
+
+.stk-block-columns .block-editor-inner-blocks > .block-editor-block-list__layout {
+	column-gap: var(--stk-column-gap, 0px);
+}

--- a/src/block/columns/style.scss
+++ b/src/block/columns/style.scss
@@ -4,3 +4,7 @@
 	min-width: 24px;
 	max-width: none;
 }
+.stk-block-columns > .stk-block-content {
+	--stk-column-gap: 0px; // For nested columns, this takes precedence.
+	column-gap: var(--stk-column-gap, 0px);
+}

--- a/src/components/resizable-column/get-snap-widths.js
+++ b/src/components/resizable-column/get-snap-widths.js
@@ -48,11 +48,14 @@ const FRACTION_WIDTHS_TENS = SNAP_WIDTHS_TENS.map( n => n * 100 )
 export const fixFractionWidths = ( columnWidths, isShiftKey = false ) => {
 	const widths = ! isShiftKey ? FRACTION_WIDTHS : FRACTION_WIDTHS_TENS
 	return columnWidths.map( width => {
-		if ( widths.includes( width - 0.1 ) ) {
-			return width - 0.1
-		} else if ( widths.includes( width + 0.1 ) ) {
-			return width + 0.1
-		}
-		return width
+		let newWidth = width
+		widths.some( snapWidth => {
+			if ( Math.abs( width - snapWidth ) < 0.2 ) {
+				newWidth = snapWidth
+				return true
+			}
+			return false
+		} )
+		return newWidth
 	} )
 }

--- a/src/components/resizable-column/index.js
+++ b/src/components/resizable-column/index.js
@@ -134,7 +134,7 @@ const ResizableColumn = props => {
 			const totalColumnGap = parentColumnGaps.desktop * ( adjacentBlocks.length - 1 )
 
 			// Get the current pixel width of the columns.
-			const parentEl = document.querySelector( `.wp-block[data-block="${ parentBlock.clientId }"]` )
+			const parentEl = document.querySelector( `.editor-styles-wrapper [data-block="${ parentBlock.clientId }"]` )
 			const parentWidth = parentEl.clientWidth - totalColumnGap
 			const isFirstResize = adjacentBlocks.every( ( { attributes } ) => ! attributes.columnWidth )
 			const columnWidths = adjacentBlocks.map( ( { clientId, attributes } ) => {
@@ -146,7 +146,7 @@ const ResizableColumn = props => {
 				if ( attributes.columnWidth ) {
 					return parentWidth * attributes.columnWidth / 100
 				}
-				const blockEl = document.querySelector( `.wp-block[data-block="${ clientId }"]` )
+				const blockEl = document.querySelector( `.editor-styles-wrapper [data-block="${ clientId }"]` )
 				return blockEl?.clientWidth || 0
 			} )
 			setCurrentWidths( columnWidths )
@@ -167,12 +167,12 @@ const ResizableColumn = props => {
 			setCurrentWidths( columnWidths )
 
 			// Get the current pixel width of the columns.
-			const blockEl = document.querySelector( `.wp-block[data-block="${ clientId }"]` )
+			const blockEl = document.querySelector( `.editor-styles-wrapper [data-block="${ clientId }"]` )
 			const columnWidth = blockEl?.clientWidth || 0
 			setCurrentWidth( columnWidth )
 
 			// The maximum width is the total width of the row.
-			const parentEl = document.querySelector( `.wp-block[data-block="${ parentBlock.clientId }"]` )
+			const parentEl = document.querySelector( `.editor-styles-wrapper [data-block="${ parentBlock.clientId }"]` )
 			const maxWidth = parentEl?.clientWidth || 0
 			setMaxWidth( maxWidth )
 		}
@@ -208,7 +208,7 @@ const ResizableColumn = props => {
 
 			// Add the temporary styles for our column widths.
 			const columnStyles = columnPercentages.map( ( width, i ) => {
-				return `.editor-styles-wrapper .wp-block[data-block="${ adjacentBlocks[ i ].clientId }"] {
+				return `.editor-styles-wrapper [data-block][data-block="${ adjacentBlocks[ i ].clientId }"] {
 					flex: 1 1 ${ width }% !important;
 					max-width: ${ width }% !important;
 				}
@@ -240,7 +240,7 @@ const ResizableColumn = props => {
 			const adjacentColumnCount = columnRows.filter( n => n === columnRows[ blockIndex ] ).length
 
 			// Add the temporary styles for our column widths.
-			const columnStyles = `.editor-styles-wrapper .wp-block[data-block="${ clientId }"] {
+			const columnStyles = `.editor-styles-wrapper [data-block][data-block="${ clientId }"] {
 					flex: 1 1 calc(${ columnPercentages }% - var(--stk-column-gap, 0px) * ${ adjacentColumnCount - 1 } / ${ adjacentColumnCount } ) !important;
 					max-width: calc(${ columnPercentages }% - var(--stk-column-gap, 0px) * ${ adjacentColumnCount - 1 } / ${ adjacentColumnCount } ) !important;
 				}

--- a/src/components/resizable-column/index.js
+++ b/src/components/resizable-column/index.js
@@ -105,6 +105,9 @@ const ResizableColumn = props => {
 		'stk-column-resizeable',
 		props.className,
 	] )
+	const {
+		columnGap, columnGapTablet, columnGapMobile,
+	} = parentBlock.attributes
 
 	const enable = useMemo( () => ( {
 		top: false,
@@ -120,11 +123,21 @@ const ResizableColumn = props => {
 	const onResizeStart = useCallback( ( _event, _direction ) => {
 		// toggleSelection( false )
 
+		// Get the column gap amounts, we need these to calculate percentages when resizing columns.
+		const parentColumnGaps = {
+			desktop: columnGap || 0,
+			tablet: columnGapTablet || columnGap || 0,
+			mobile: columnGapMobile || columnGapTablet || columnGap || 0,
+		}
+
 		// In desktop, get all the column widths.
 		if ( isDesktop ) {
+			// In desktop, the column gaps will affect the width of the parent column, take it into account.
+			const totalColumnGap = parentColumnGaps.desktop * ( adjacentBlocks.length - 1 )
+
 			// Get the current pixel width of the columns.
 			const parentEl = document.querySelector( `[data-block="${ parentBlock.clientId }"]` )
-			const parentWidth = parentEl.clientWidth
+			const parentWidth = parentEl.clientWidth - totalColumnGap
 			const isFirstResize = adjacentBlocks.every( ( { attributes } ) => ! attributes.columnWidth )
 			const columnWidths = adjacentBlocks.map( ( { clientId, attributes } ) => {
 				// If columns haven't been resized yet, create default values.
@@ -161,7 +174,7 @@ const ResizableColumn = props => {
 		}
 
 		setIsTooltipOver( true )
-	}, [ isDesktop, parentBlock?.clientId, adjacentBlocks, blockIndex, clientId ] )
+	}, [ isDesktop, parentBlock?.clientId, adjacentBlocks, blockIndex, clientId, columnGap, columnGapTablet, columnGapMobile ] )
 
 	const onResize = useCallback( ( _event, _direction, elt, delta ) => {
 		let columnPercentages = []

--- a/src/components/resizable-column/index.js
+++ b/src/components/resizable-column/index.js
@@ -134,7 +134,7 @@ const ResizableColumn = props => {
 			const totalColumnGap = parentColumnGaps.desktop * ( adjacentBlocks.length - 1 )
 
 			// Get the current pixel width of the columns.
-			const parentEl = document.querySelector( `[data-block="${ parentBlock.clientId }"]` )
+			const parentEl = document.querySelector( `.wp-block[data-block="${ parentBlock.clientId }"]` )
 			const parentWidth = parentEl.clientWidth - totalColumnGap
 			const isFirstResize = adjacentBlocks.every( ( { attributes } ) => ! attributes.columnWidth )
 			const columnWidths = adjacentBlocks.map( ( { clientId, attributes } ) => {
@@ -146,7 +146,7 @@ const ResizableColumn = props => {
 				if ( attributes.columnWidth ) {
 					return parentWidth * attributes.columnWidth / 100
 				}
-				const blockEl = document.querySelector( `[data-block="${ clientId }"]` )
+				const blockEl = document.querySelector( `.wp-block[data-block="${ clientId }"]` )
 				return blockEl?.clientWidth || 0
 			} )
 			setCurrentWidths( columnWidths )
@@ -167,12 +167,12 @@ const ResizableColumn = props => {
 			setCurrentWidths( columnWidths )
 
 			// Get the current pixel width of the columns.
-			const blockEl = document.querySelector( `[data-block="${ clientId }"]` )
+			const blockEl = document.querySelector( `.wp-block[data-block="${ clientId }"]` )
 			const columnWidth = blockEl?.clientWidth || 0
 			setCurrentWidth( columnWidth )
 
 			// The maximum width is the total width of the row.
-			const parentEl = document.querySelector( `[data-block="${ parentBlock.clientId }"]` )
+			const parentEl = document.querySelector( `.wp-block[data-block="${ parentBlock.clientId }"]` )
 			const maxWidth = parentEl?.clientWidth || 0
 			setMaxWidth( maxWidth )
 		}

--- a/src/components/resizable-column/index.js
+++ b/src/components/resizable-column/index.js
@@ -17,6 +17,7 @@ import {
 import { clamp, isEqual } from 'lodash'
 import classnames from 'classnames'
 import { i18n } from 'stackable'
+import { getRowsFromColumns } from '~stackable/block-components/column/util'
 
 /**
  * WordPress dependencies
@@ -28,11 +29,7 @@ import {
 } from '@wordpress/element'
 import { useBlockEditContext } from '@wordpress/block-editor'
 
-const MIN_COLUMN_WIDTHS = {
-	Desktop: 100,
-	Tablet: 50,
-	Mobile: 50,
-}
+const MIN_COLUMN_WIDTH = 30
 
 const MIN_COLUMN_WIDTH_PERCENTAGE = {
 	Desktop: 5,
@@ -57,6 +54,7 @@ const ResizableColumn = props => {
 	useDeviceEditorClasses()
 
 	const [ currentWidths, setCurrentWidths ] = useState( [] )
+	const [ currentWidth, setCurrentWidth ] = useState( '' )
 	const [ newWidthsPercent, setNewWidthsPercent ] = useState( [] )
 	const [ maxWidth, setMaxWidth ] = useState( 2000 )
 	const [ tempStyles, setTempStyles ] = useState( '' )
@@ -157,15 +155,21 @@ const ResizableColumn = props => {
 			// width depends on the adjacent block, the adjacent should
 			// not go past the minimum.
 			const adjacentBlockIndex = _direction === 'right' ? blockIndex + 1 : blockIndex - 1
-			const maxWidth = columnWidths[ blockIndex ] + ( columnWidths[ adjacentBlockIndex ] - MIN_COLUMN_WIDTHS.Desktop )
+			const maxWidth = columnWidths[ blockIndex ] + ( columnWidths[ adjacentBlockIndex ] - MIN_COLUMN_WIDTH )
 			setMaxWidth( maxWidth )
 
 		// Tablet and mobile.
 		} else {
 			// Get the current pixel width of the columns.
+			const columnWidths = adjacentBlocks.map( ( { attributes } ) => {
+				return attributes.columnWidthTablet || attributes.columnWidth || 100 / adjacentBlocks.length
+			} )
+			setCurrentWidths( columnWidths )
+
+			// Get the current pixel width of the columns.
 			const blockEl = document.querySelector( `[data-block="${ clientId }"]` )
 			const columnWidth = blockEl?.clientWidth || 0
-			setCurrentWidths( columnWidth )
+			setCurrentWidth( columnWidth )
 
 			// The maximum width is the total width of the row.
 			const parentEl = document.querySelector( `[data-block="${ parentBlock.clientId }"]` )
@@ -224,15 +228,21 @@ const ResizableColumn = props => {
 		// adjusted alone, it can span the whole width for responsive
 		// control.
 		} else {
-			const newWidth = currentWidths + delta.width
+			const newWidth = currentWidth + delta.width
 			columnPercentages = clamp( parseFloat( ( newWidth / maxWidth * 100 ).toFixed( 1 ) ), 0, 100 )
 
 			setNewWidthsPercent( columnPercentages )
 
+			// Take into account the number of adjacent columns per row
+			const widths = [ ...currentWidths ]
+			widths[ blockIndex ] = columnPercentages
+			const columnRows = getRowsFromColumns( widths )
+			const adjacentColumnCount = columnRows.filter( n => n === columnRows[ blockIndex ] ).length
+
 			// Add the temporary styles for our column widths.
 			const columnStyles = `.editor-styles-wrapper [data-block="${ clientId }"] {
-					flex: 1 1 ${ columnPercentages }% !important;
-					max-width: ${ columnPercentages }% !important;
+					flex: 1 1 calc(${ columnPercentages }% - var(--stk-column-gap, 0px) * ${ adjacentColumnCount - 1 } / ${ adjacentColumnCount } ) !important;
+					max-width: calc(${ columnPercentages }% - var(--stk-column-gap, 0px) * ${ adjacentColumnCount - 1 } / ${ adjacentColumnCount } ) !important;
 				}
 				[data-block="${ clientId }"] .stk-resizable-column__size-tooltip {
 					--width: '${ columnPercentages.toFixed( 1 ) }%' !important;
@@ -245,7 +255,7 @@ const ResizableColumn = props => {
 				setSnapWidths( { x: getSnapWidths( [ 100 ], 0, maxWidth, _direction, isShiftKey ) } )
 			}
 		}
-	}, [ isDesktop, currentWidths, blockIndex, adjacentBlocks, isShiftKey, maxWidth, clientId, snapWidths ] )
+	}, [ isDesktop, currentWidths, currentWidth, blockIndex, adjacentBlocks, isShiftKey, maxWidth, clientId, snapWidths ] )
 
 	const onResizeStop = useCallback( ( _event, _direction, elt, delta ) => {
 		// Update the block widths.
@@ -259,9 +269,20 @@ const ResizableColumn = props => {
 					props.onChangeDesktop( newWidthsPercent )
 				}
 			} else if ( isTablet ) {
-				props.onChangeTablet( newWidthsPercent )
+				// Get the current column widths for tablet.
+				const columnWidths = adjacentBlocks.map( ( { attributes } ) => {
+					return attributes.columnWidthTablet || attributes.columnWidth || 100 / adjacentBlocks.length
+				} )
+				columnWidths[ blockIndex ] = newWidthsPercent
+
+				props.onChangeTablet( newWidthsPercent, columnWidths, blockIndex )
 			} else {
-				props.onChangeMobile( newWidthsPercent )
+				// Get the current column widths for mobile.
+				const columnWidths = adjacentBlocks.map( ( { attributes } ) => {
+					return attributes.columnWidthMobile || 100
+				} )
+				columnWidths[ blockIndex ] = newWidthsPercent
+				props.onChangeMobile( newWidthsPercent, columnWidths, blockIndex )
 			}
 		}
 
@@ -276,10 +297,10 @@ const ResizableColumn = props => {
 
 		setSnapWidths( null )
 		setIsTooltipOver( false )
-	}, [ isDesktop, isTablet, newWidthsPercent, props.onChangeDesktop, props.onChangeTablet, props.onChangeMobile, tempStyles, isMounted ] )
+	}, [ isDesktop, isTablet, newWidthsPercent, props.onChangeDesktop, props.onChangeTablet, props.onChangeMobile, tempStyles, adjacentBlocks, blockIndex, isMounted ] )
 
 	const onTooltipChange = useCallback( width => {
-		if ( width < MIN_COLUMN_WIDTH_PERCENTAGE[ deviceType ] ) {
+		if ( width !== '' && width < MIN_COLUMN_WIDTH_PERCENTAGE[ deviceType ] ) {
 			return
 		}
 
@@ -307,14 +328,30 @@ const ResizableColumn = props => {
 			columnWidths[ blockIndex ] = finalWidth
 
 			props.onChangeDesktop( columnWidths )
-		} else {
+		} else if ( isTablet ) {
+			// Get the current column widths.
+			const columnWidths = adjacentBlocks.map( ( { attributes } ) => {
+				return attributes.columnWidthTablet || attributes.columnWidth || 100 / adjacentBlocks.length
+			} )
+
 			// Tablet and Mobile.
-			const finalWidth = clamp( width, MIN_COLUMN_WIDTH_PERCENTAGE[ deviceType ], 100 )
-			if ( isTablet ) {
-				props.onChangeTablet( finalWidth )
-			} else {
-				props.onChangeMobile( finalWidth )
-			}
+			const finalWidth = width ? clamp( width, MIN_COLUMN_WIDTH_PERCENTAGE[ deviceType ], 100 ) : ''
+
+			columnWidths[ blockIndex ] = finalWidth
+
+			props.onChangeTablet( finalWidth, columnWidths, blockIndex )
+		} else {
+			// Get the current column widths.
+			const columnWidths = adjacentBlocks.map( ( { attributes } ) => {
+				return attributes.columnWidthMobile || 100
+			} )
+
+			// Tablet and Mobile.
+			const finalWidth = width ? clamp( width, MIN_COLUMN_WIDTH_PERCENTAGE[ deviceType ], 100 ) : ''
+
+			columnWidths[ blockIndex ] = finalWidth
+
+			props.onChangeMobile( finalWidth, columnWidths, blockIndex )
 		}
 	}, [ deviceType, isDesktop, isTablet, adjacentBlocks, blockIndex ] )
 
@@ -353,7 +390,7 @@ const ResizableColumn = props => {
 	return (
 		<ResizableBox
 			enable={ enable }
-			minWidth={ MIN_COLUMN_WIDTHS[ deviceType ] }
+			minWidth="30" // Need to use String here or else ResizableBox will not snap properly when coming from the minimum width.
 			minHeight="100"
 			maxWidth={ maxWidth }
 			className={ className }
@@ -383,7 +420,7 @@ const ResizableColumn = props => {
 	)
 }
 
-const ResizableTooltip = props => {
+const ResizableTooltip = memo( props => {
 	const {
 		adjacentBlocks, isOnlyBlock, blockIndex, isLastBlock, isFirstBlock,
 	} = props.blockContext
@@ -492,7 +529,12 @@ const ResizableTooltip = props => {
 							value={ currentInputValue }
 							allowReset={ false }
 							onChange={ value => {
-								props.onChange( clamp( value, 0, 100 ) || originalInputValue )
+								const resetValue = deviceType === 'Desktop' ? originalInputValue : ''
+								const newValue = clamp( value, 0, 100 ) || resetValue
+								if ( newValue === '' ) {
+									setOriginalInputValue( '' )
+								}
+								props.onChange( newValue )
 								setCurrentInputValue( value )
 							} }
 							onKeyDown={ event => {
@@ -503,7 +545,7 @@ const ResizableTooltip = props => {
 									event.preventDefault()
 								}
 							} }
-							placeholder={ originalInputValue || columnLabel }
+							placeholder={ originalInputValue || columnLabel || props.value }
 						/>
 					</div>
 				</Popover>
@@ -532,7 +574,7 @@ const ResizableTooltip = props => {
 			}
 		</Fragment>
 	)
-}
+} )
 
 ResizableTooltip.defaultProps = {
 	isVisible: true,

--- a/src/components/resizable-column/index.js
+++ b/src/components/resizable-column/index.js
@@ -208,7 +208,7 @@ const ResizableColumn = props => {
 
 			// Add the temporary styles for our column widths.
 			const columnStyles = columnPercentages.map( ( width, i ) => {
-				return `.editor-styles-wrapper [data-block="${ adjacentBlocks[ i ].clientId }"] {
+				return `.editor-styles-wrapper .wp-block[data-block="${ adjacentBlocks[ i ].clientId }"] {
 					flex: 1 1 ${ width }% !important;
 					max-width: ${ width }% !important;
 				}
@@ -240,7 +240,7 @@ const ResizableColumn = props => {
 			const adjacentColumnCount = columnRows.filter( n => n === columnRows[ blockIndex ] ).length
 
 			// Add the temporary styles for our column widths.
-			const columnStyles = `.editor-styles-wrapper [data-block="${ clientId }"] {
+			const columnStyles = `.editor-styles-wrapper .wp-block[data-block="${ clientId }"] {
 					flex: 1 1 calc(${ columnPercentages }% - var(--stk-column-gap, 0px) * ${ adjacentColumnCount - 1 } / ${ adjacentColumnCount } ) !important;
 					max-width: calc(${ columnPercentages }% - var(--stk-column-gap, 0px) * ${ adjacentColumnCount - 1 } / ${ adjacentColumnCount } ) !important;
 				}

--- a/src/hooks/use-block-context.js
+++ b/src/hooks/use-block-context.js
@@ -31,7 +31,7 @@ const useBlockContext = ( blockClientId = null ) => {
 			// Check if a column block isn't used as a row. If not, then don't
 			// use row-like properties (column resizers, etc).
 			if ( hasParent && block.name === 'stackable/column' ) {
-				const isRow = document.querySelector( `[data-block="${ parent.clientId }"] .stk-block` )?.classList.contains( 'stk-row' )
+				const isRow = document.querySelector( `.wp-block[data-block="${ parent.clientId }"] .stk-block` )?.classList.contains( 'stk-row' )
 				if ( ! isRow ) {
 					return {
 						blockIndex: index,

--- a/src/hooks/use-block-context.js
+++ b/src/hooks/use-block-context.js
@@ -31,7 +31,7 @@ const useBlockContext = ( blockClientId = null ) => {
 			// Check if a column block isn't used as a row. If not, then don't
 			// use row-like properties (column resizers, etc).
 			if ( hasParent && block.name === 'stackable/column' ) {
-				const isRow = document.querySelector( `.wp-block[data-block="${ parent.clientId }"] .stk-block` )?.classList.contains( 'stk-row' )
+				const isRow = document.querySelector( `.editor-styles-wrapper [data-block="${ parent.clientId }"] .stk-block` )?.classList.contains( 'stk-row' )
 				if ( ! isRow ) {
 					return {
 						blockIndex: index,

--- a/src/hooks/use-block-hover-state.js
+++ b/src/hooks/use-block-hover-state.js
@@ -21,8 +21,8 @@ const DEFAULT_STATE = {
 
 const STORE_ACTIONS = {
 	updateSelectedBlock: clientId => {
-		// We need to specify `.edit-post-visual-editor__content-area` to avoid targeting the navigation list view.
-		const blockEl = document.querySelector( `.edit-post-visual-editor__content-area [data-block="${ clientId }"]` )
+		// We need to specify `.editor-styles-wrapper` to avoid targeting the navigation list view.
+		const blockEl = document.querySelector( `.editor-styles-wrapper [data-block="${ clientId }"]` )
 
 		// Get the currently parent-hovered block if there is one.
 		const parentHoverEl = blockEl?.closest( '.stk-hover-parent' )?.closest( '[data-block]' )

--- a/src/plugins/design-library-button/design-library-button.js
+++ b/src/plugins/design-library-button/design-library-button.js
@@ -21,7 +21,7 @@ const DesignLibraryButton = () => {
 
 				dispatch( 'core/block-editor' ).insertBlocks( block )
 					.then( () => {
-						const button = document.querySelector( `.wp-block[data-block="${ block.clientId }"] button` )
+						const button = document.querySelector( `.editor-styles-wrapper [data-block="${ block.clientId }"] button` )
 						// Open the design library.
 						if ( button ) {
 							button.click()

--- a/src/plugins/design-library-button/design-library-button.js
+++ b/src/plugins/design-library-button/design-library-button.js
@@ -21,7 +21,7 @@ const DesignLibraryButton = () => {
 
 				dispatch( 'core/block-editor' ).insertBlocks( block )
 					.then( () => {
-						const button = document.querySelector( `[data-block="${ block.clientId }"] button` )
+						const button = document.querySelector( `.wp-block[data-block="${ block.clientId }"] button` )
 						// Open the design library.
 						if ( button ) {
 							button.click()

--- a/src/styles/block-transitions.scss
+++ b/src/styles/block-transitions.scss
@@ -29,7 +29,7 @@ body.stk--anim-init {
 	.stk-block .stk-button::before, // For button animations
 	.stk-block .stk-button::after, // For button animations
 	.stk-block li::marker { // For icon list marker
-		transition: all 0.12s cubic-bezier(0.45, 0.05, 0.55, 0.95);
+		transition: all 0.12s cubic-bezier(0.45, 0.05, 0.55, 0.95), flex 0s, max-width 0s; // Don't include flex & max-width since column widths would animate.
 		border-width: 1px;
 		border-style: none;
 	}

--- a/src/styles/editor-block-transitions.scss
+++ b/src/styles/editor-block-transitions.scss
@@ -25,7 +25,7 @@
 	.stk-block .stk-button::before, // For button animations
 	.stk-block .stk-button::after, // For button animations
 	.stk-block li::marker { // For icon list marker
-		transition: all 0.12s cubic-bezier(0.45, 0.05, 0.55, 0.95), margin 0s;
+		transition: all 0.12s cubic-bezier(0.45, 0.05, 0.55, 0.95), margin 0s, flex 0s, max-width 0s; // Don't include flex & max-width since column widths would animate.
 		border-width: 1px;
 		border-style: none;
 	}

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -306,7 +306,7 @@ export const prependCSSClass = ( cssSelector, mainClassName = '', uniqueClassNam
 		.split( ',' )
 		.map( s => {
 			let newSelector = ''
-			if ( s.startsWith( '[data-block' ) ) {
+			if ( s.includes( '[data-block=' ) ) {
 				newSelector = s
 			} else if ( s.includes( '%s' ) ) {
 				newSelector = s.replaceAll( '%s', uniqueClassName )

--- a/src/util/styles/index.js
+++ b/src/util/styles/index.js
@@ -154,7 +154,7 @@ export const appendImportant = ( rule, doImportant = true ) => {
 export const __getValue = ( attributes, attrNameCallback = null, defaultValue_ = undefined ) => ( attrName, format = '', defaultValue = defaultValue_ ) => {
 	const attrNameFunc = attrNameCallback !== null ? attrNameCallback : ( s => lowerFirst( s ) )
 	const value = typeof attributes[ attrNameFunc( attrName ) ] === 'undefined' ? '' : attributes[ attrNameFunc( attrName ) ]
-	return value !== '' ? ( format ? sprintf( format.replace( /%$/, '%%' ), value ) : value ) : defaultValue
+	return value !== '' ? ( format ? sprintf( format.replace( /%([sd])%/, '%$1%%' ), value ) : value ) : defaultValue
 }
 
 /**


### PR DESCRIPTION
This PR fixes the following issues when a Columns block has a column gap (e.g. `50` pixel column gap)
- [x] Resizing columns by dragging becomes wonky in desktop
- [x] When previewing in tablet or mobile, using a 50% 50% layout always pushes the other column to the next row
- [x] Typing in the widths directly in tablet or mobile doesn't resize the columns correctly

Other fixes:
- [x] In a 50% 50% desktop layout, adding a -200px left margin on the second column should stretch the column to the left in the frontend.
- [x] Added a row-gap option to the Columns block