### PR TITLE
fix: column gap inherited from desktop collapses tablet columns

### DIFF
--- a/src/block-components/column/style.js
+++ b/src/block-components/column/style.js
@@ -43,9 +43,6 @@ const getStyleParams = ( options = {} ) => {
 			format: '%s%',
 			dependencies: [ 'columnAdjacentCount' ],
 			valueCallback: ( value, getAttribute, device ) => {
-				if ( device === 'desktop' ) {
-					return value
-				}
 				const adjacentCount = getAttribute( 'columnAdjacentCount', device )
 				if ( adjacentCount ) {
 					return value.replace( /([\d\.]+%)$/, `calc($1 - var(--stk-column-gap, 0px) * ${ adjacentCount - 1 } / ${ adjacentCount } )` )
@@ -72,10 +69,6 @@ const getStyleParams = ( options = {} ) => {
 				//
 				// No need to do this in the editor since it already does this.
 				const value = device === 'desktop' ? _value : _value.replace( /^1 1/, '0 1' )
-
-				if ( device === 'desktop' ) {
-					return value
-				}
 
 				const adjacentCount = getAttribute( 'columnAdjacentCount', device )
 				if ( adjacentCount ) {

--- a/src/block-components/column/use-column.js
+++ b/src/block-components/column/use-column.js
@@ -21,7 +21,10 @@ export const useColumn = () => {
 			if ( adjacentBlocks.length ) {
 				widths.forEach( ( width, i ) => {
 				// TODO: When Gutenberg 10.1 comes out, update this to just one updateBlockAttributes call for all client Ids
-					updateBlockAttributes( adjacentBlocks[ i ].clientId, { columnWidth: width } )
+					updateBlockAttributes( adjacentBlocks[ i ].clientId, {
+						columnWidth: width,
+						columnAdjacentCount: widths.length,
+					} )
 				} )
 			}
 		},


### PR DESCRIPTION
How to replicate:
1. create 2 columns
2. add column gap 100px
3. change the column width to 40% & 60%
4. preview in frontend, then resize browser to tablet size. See that the columns will collapse