### PR TITLE
fix (wp5.9): testimonial block goes out of tablet and mobile preview bounds

### DIFF
--- a/src/styles/editor-block.scss
+++ b/src/styles/editor-block.scss
@@ -24,6 +24,10 @@
 	margin-bottom: 0;
 	z-index: 1;
 }
+// The block contents may go out of bounds in tablet/mobile editor preview.
+.stk-block-content {
+	box-sizing: border-box;
+}
 
 // Add small margin between blocks so that placing your mouse between blocks
 // will make the block appender appear.


### PR DESCRIPTION
Fixes #2120