### PR TITLE
Prevent dynamic content popover from closing when clicking reset buttons or items on the suggestions dropdown within the popover.

### DIFF
--- a/src/components/dynamic-content-control/index.js
+++ b/src/components/dynamic-content-control/index.js
@@ -54,10 +54,18 @@ export const useDynamicContentControlProps = props => {
 
 	const clickOutsideListener = useCallback( event => {
 		if ( isPopoverOpen ) {
+			/*
+			 * Unfortunately, `event.target.closest( '.stackable-dynamic-content__popover' )`
+			 * returns `null` if the target element gets removed from the DOM
+			 * which is the case for the reset button and the items in the
+			 * suggestion list. We need to whitelist those cases too.
+			 */
 			if (
 				! event.target.closest( '.stackable-dynamic-content__popover' ) &&
-				! event.target.closest( '.stackable-dynamic-content__popover' ) &&
-				! event.target.closest( '.stk-dynamic-content-control__button' )
+				! event.target.closest( '.stk-dynamic-content-control__button' ) &&
+				! event.target.closest( '.stk-inspector-control__reset-button' ) &&
+				! ( event.target.classList.contains( 'ugb-autosuggest-option' ) ||
+				event.target.classList.contains( 'react-autosuggest__suggestion' ) )
 			) {
 				setIsPopoverOpen( false )
 			}


### PR DESCRIPTION
Fixes https://github.com/gambitph/Stackable/issues/2119.

