### PR TITLE
Use mousedown instead of click to prevent dynamic content popover fro…

### DIFF
--- a/src/components/dynamic-content-control/index.js
+++ b/src/components/dynamic-content-control/index.js
@@ -56,7 +56,6 @@ export const useDynamicContentControlProps = props => {
 		if ( isPopoverOpen ) {
 			if (
 				! event.target.closest( '.stackable-dynamic-content__popover' ) &&
-				! event.target.closest( '.stackable-dynamic-content__popover' ) &&
 				! event.target.closest( '.stk-dynamic-content-control__button' )
 			) {
 				setIsPopoverOpen( false )
@@ -65,8 +64,8 @@ export const useDynamicContentControlProps = props => {
 	} )
 
 	useEffect( () => {
-		document.body.addEventListener( 'click', clickOutsideListener )
-		return () => document.body.removeEventListener( 'click', clickOutsideListener )
+		document.body.addEventListener( 'mousedown', clickOutsideListener )
+		return () => document.body.removeEventListener( 'mousedown', clickOutsideListener )
 	}, [ clickOutsideListener ] )
 
 	useEffect( () => {


### PR DESCRIPTION
…m closing when clicking reset buttons or items on the suggestions dropdown within the popover.

Fixes https://github.com/gambitph/Stackable/issues/2119