### PR TITLE
Fix: enable repick of image when image is already picked in stackable image block.

### DIFF
--- a/src/block-components/image/image.js
+++ b/src/block-components/image/image.js
@@ -166,7 +166,8 @@ const Image = memo( props => {
 							if ( props.enableClickToEdit ) {
 								if ( event.target?.classList?.contains( 'stk-img' ) ||
 									event.target?.classList?.contains( 'stk-img-placeholder' ) ||
-									event.target?.classList?.contains( 'stk-img-resizer-wrapper' )
+									event.target?.classList?.contains( 'stk-img-resizer-wrapper' ) ||
+									event.target?.classList?.contains( 'stk-img-resizer' )
 								) {
 									obj.open()
 								}


### PR DESCRIPTION
Fixes https://github.com/gambitph/Stackable/issues/2133.