### PR TITLE
Fix buttons' missing shadow when border radius is enabled.

### DIFF
--- a/src/block-components/button/style.js
+++ b/src/block-components/button/style.js
@@ -178,6 +178,10 @@ export const Style = props => {
 					options: {
 						...propsToPass.options,
 						selector: propsToPass.options.selector + ':before',
+						// Adding border radius clips button's shadow.
+						// This prevents this from happening.
+						// @see src/block-components/borders/style.js
+						addBorderRadiusOverflow: false,
 						hoverSelector: propsToPass.options.selector + ':hover:before',
 						borderRadiusSelector: propsToPass.options.selector,
 						attrNameTemplate: sprintf( 'button%s', propsToPass.options?.attrNameTemplate || '%s' ),
@@ -216,6 +220,10 @@ Style.Content = props => {
 					options: {
 						...propsToPass.options,
 						selector: propsToPass.options.selector + ':before',
+						// Adding border radius clips button's shadow.
+						// This prevents this from happening.
+						// @see src/block-components/borders/style.js
+						addBorderRadiusOverflow: false,
 						hoverSelector: propsToPass.options.selector + ':hover:before',
 						borderRadiusSelector: propsToPass.options.selector,
 						attrNameTemplate: sprintf( 'button%s', propsToPass.options?.attrNameTemplate || '%s' ),

--- a/src/block-components/helpers/borders/style.js
+++ b/src/block-components/helpers/borders/style.js
@@ -11,6 +11,7 @@ import { Fragment } from '@wordpress/element'
 
 const getStyleParams = ( options = {} ) => {
 	const {
+		addBorderRadiusOverflow = true,
 		selector = '',
 		attrNameTemplate = '%s',
 		hoverSelector,
@@ -29,6 +30,7 @@ const getStyleParams = ( options = {} ) => {
 			hoverSelector: borderRadiusSelector ? undefined : hoverSelector,
 		},
 		// Adding a border radius should append `overflow: hidden`.
+		// This is to prevent gradient background from overflowing.
 		{
 			selector: borderRadiusSelector || selector,
 			styleRule: 'overflow',
@@ -37,6 +39,7 @@ const getStyleParams = ( options = {} ) => {
 			responsive: 'all',
 			hover: 'all',
 			hoverSelector: borderRadiusSelector ? undefined : hoverSelector,
+			enabledCallback: () => addBorderRadiusOverflow,
 			valueCallback: () => 'hidden',
 		},
 		{


### PR DESCRIPTION
Fixes https://github.com/gambitph/Stackable/issues/2162

* Add addBorderRadiusOverflow option to BorderStyle.
* Add enabledCallback block-components/helpers/borders/styles.