### PR TITLE
Removed selector so that button text will wrap. Added condition to prevent buttons from navigating within editor. 

### DIFF
--- a/src/block/button-group/style.js
+++ b/src/block/button-group/style.js
@@ -47,6 +47,9 @@ const getStyleParams = () => {
 			styleRule: 'flexWrap',
 			attrName: 'flexWrap',
 			responsive: 'all',
+			valuePreCallback: value => {
+				return value || 'nowrap'
+			},
 		},
 		{
 			renderIn: 'save',

--- a/src/block/button/edit.js
+++ b/src/block/button/edit.js
@@ -20,6 +20,7 @@ import {
 	EffectsAnimations,
 	ConditionalDisplay,
 	Transform,
+	getAlignmentClasses,
 } from '~stackable/block-components'
 import {
 	useBlockHoverClass, useBlockStyle,
@@ -31,7 +32,9 @@ import { withQueryLoopContext } from '~stackable/higher-order'
  */
 import { __ } from '@wordpress/i18n'
 import { createBlock } from '@wordpress/blocks'
-import { useBlockProps } from '@wordpress/block-editor'
+import {
+	AlignmentToolbar, BlockControls, useBlockProps,
+} from '@wordpress/block-editor'
 
 /**
  * Internal dependencies
@@ -44,6 +47,7 @@ const Edit = props => {
 		className,
 		onReplace,
 		attributes,
+		setAttributes,
 	} = props
 
 	useGeneratedCss( props.attributes )
@@ -58,12 +62,14 @@ const Edit = props => {
 	const customAttributes = CustomAttributes.getCustomAttributes( props.attributes )
 
 	const blockHoverClass = useBlockHoverClass()
+	const blockAlignmentClass = getAlignmentClasses( props.attributes )
 
 	const blockStyle = useBlockStyle( blockStyles )
 
 	const blockClassNames = classnames( [
 		className,
 		'stk-block-button',
+		blockAlignmentClass,
 		blockHoverClass,
 		// We need to add the blockStyle here to append the class alongside `.stk-block`
 		// Only in the editor.
@@ -79,6 +85,12 @@ const Edit = props => {
 
 	return (
 		<>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ attributes.contentAlign }
+					onChange={ contentAlign => setAttributes( { contentAlign } ) }
+				/>
+			</BlockControls>
 
 			<InspectorTabs />
 			<BlockDiv.InspectorControls />

--- a/src/block/button/save.js
+++ b/src/block/button/save.js
@@ -12,6 +12,7 @@ import {
 	Typography,
 	getResponsiveClasses,
 	CustomAttributes,
+	getAlignmentClasses,
 } from '~stackable/block-components'
 
 /**
@@ -35,10 +36,12 @@ export const Save = props => {
 	const customAttributes = CustomAttributes.getCustomAttributes( props.attributes )
 
 	const typographyInnerClasses = getTypographyClasses( props.attributes )
+	const blockAlignmentClass = getAlignmentClasses( props.attributes )
 
 	const blockClassNames = classnames( [
 		className,
 		'stk-block-button',
+		blockAlignmentClass,
 		responsiveClass,
 	] )
 

--- a/src/block/button/schema.js
+++ b/src/block/button/schema.js
@@ -37,6 +37,18 @@ export const attributes = ( version = VERSION ) => {
 		hasColor: false,
 	} )
 
+	attrObject.add( {
+		attributes: {
+			contentAlign: {
+				stkResponsive: true,
+				type: 'string',
+				default: '',
+			},
+		},
+		versionAdded: '3.0.0',
+		versionDeprecated: '',
+	} )
+
 	return attrObject.getMerged( version )
 }
 

--- a/src/components/link/index.js
+++ b/src/components/link/index.js
@@ -27,7 +27,7 @@ const Link = forwardRef( ( props, ref ) => {
 		<TagName
 			ref={ ref }
 			className={ classNames }
-			href="#0" // Disallow links in the editor
+			href={ tagName === 'a' ? 'javascript:void(0)' : undefined } // Disallow links in the editor
 			{ ...propsToPass }
 		>
 			{ children }

--- a/src/styles/block.scss
+++ b/src/styles/block.scss
@@ -303,9 +303,6 @@
 }
 
 // Buttons.
-.stk-button {
-	width: max-content;
-}
 :is(.stk-block-button, .stk-block-icon-button, .stk-block-pagination, .stk-block-load-more, .stk-block-posts) {
 	&:not(.is-style-link) {
 		.stk-button {


### PR DESCRIPTION
Fixes #2039. Fixes button being able to navigate while editing in mobile preview. 