### PR TITLE
Fix eye icon overlapping with ToC item text.

### DIFF
--- a/src/block/column/edit.js
+++ b/src/block/column/edit.js
@@ -15,12 +15,8 @@ import {
 	InspectorTabs,
 	PanelAdvancedSettings,
 } from '~stackable/components'
-import {
-	useBlockContext, useBlockHoverClass,
-} from '~stackable/hooks'
-import {
-	withIsHovered, withQueryLoopContext,
-} from '~stackable/higher-order'
+import { useBlockContext, useBlockHoverClass } from '~stackable/hooks'
+import { withIsHovered, withQueryLoopContext } from '~stackable/higher-order'
 import {
 	Column,
 	getColumnClasses,
@@ -46,9 +42,7 @@ import {
  */
 import { compose } from '@wordpress/compose'
 import { InnerBlocks } from '@wordpress/block-editor'
-import {
-	Fragment, useMemo,
-} from '@wordpress/element'
+import { Fragment, useMemo } from '@wordpress/element'
 import { __ } from '@wordpress/i18n'
 import { useSelect } from '@wordpress/data'
 import { applyFilters } from '@wordpress/hooks'

--- a/src/block/table-of-contents/editor.scss
+++ b/src/block/table-of-contents/editor.scss
@@ -31,6 +31,8 @@
 
 	.stk-block-table-of-contents__list-item__exclude-button {
 		display: inline-block;
+		height: auto;
+		vertical-align: middle;
 	}
 
 	.stk-block-table-of-contents__list-item__excluded {

--- a/src/block/table-of-contents/editor.scss
+++ b/src/block/table-of-contents/editor.scss
@@ -26,10 +26,11 @@
 	}
 
 	.stk-block-table-of-contents__list-item-inner {
-		display: flex;
-		align-items: center;
-		justify-content: flex-start;
-		flex-wrap: nowrap;
+		display: block;
+	}
+
+	.stk-block-table-of-contents__list-item__exclude-button {
+		display: inline-block;
 	}
 
 	.stk-block-table-of-contents__list-item__excluded {
@@ -45,14 +46,10 @@
 
 	// For the visibility toggle styles.
 	.stk-block-table-of-contents__link-wrapper {
-		position: relative;
-		padding-right: 52px;
+		display: block;
 	}
+
 	.stk-block-table-of-contents__list-item__exclude-button {
-		position: absolute;
-		top: 50%;
-		transform: translateY(-50%);
-		margin-left: 16px;
 		&:focus {
 			box-shadow: none;
 		}

--- a/src/block/table-of-contents/style.js
+++ b/src/block/table-of-contents/style.js
@@ -132,6 +132,15 @@ const getStyleParams = () => {
 			responsive: 'all',
 			format: '%spx',
 		},
+		// This fixes the issue where the bullet becomes small when a global font size is set.
+		{
+			renderIn: 'edit',
+			selector: '.%s.%s li',
+			styleRule: 'fontSize',
+			attrName: 'fontSize',
+			responsive: 'all',
+			format: '%spx',
+		},
 	]
 }
 

--- a/src/block/table-of-contents/style.scss
+++ b/src/block/table-of-contents/style.scss
@@ -5,6 +5,17 @@
 		column-gap: 32px;
 	}
 
+	// This fixes columns breaking if a line has long text.
+	li {
+		/* autoprefixer: ignore next */
+		-webkit-column-break-inside: avoid;
+		/* autoprefixer: ignore next */
+		-moz-column-break-inside: avoid;
+		-o-column-break-inside: avoid;
+		-ms-column-break-inside: avoid;
+		column-break-inside: avoid;
+	}
+
 	:is(ul, ol) {
 		padding-inline-start: 1em;
 	}


### PR DESCRIPTION
* Change display property from flex to inline block.
* Change display property of parent from inline to block.

Fixes: https://github.com/gambitph/Stackable/issues/2207