### PR TITLE
Removed alignment options in icon label block and changed the max-width of the header within said block. 

### DIFF
--- a/src/block/icon-label/edit.js
+++ b/src/block/icon-label/edit.js
@@ -20,7 +20,6 @@ import {
 	useGeneratedCss,
 	MarginBottom,
 	getRowClasses,
-	Alignment,
 	getAlignmentClasses,
 	Advanced,
 	CustomCSS,
@@ -74,8 +73,6 @@ const Edit = props => {
 	return (
 		<Fragment>
 			<InspectorTabs />
-
-			<Alignment.InspectorControls />
 			<BlockDiv.InspectorControls />
 			<InspectorStyleControls>
 				<PanelAdvancedSettings

--- a/src/block/icon-label/editor.scss
+++ b/src/block/icon-label/editor.scss
@@ -1,5 +1,8 @@
 .stk-block-icon-label [data-type="stackable/icon"] {
 	flex: 0 0 64px;
+	.stk-inner-blocks.stk-block-content {
+		max-width: unset !important;
+	}
 }
 // Icon label can collapse in mobile in the editor.
 .stk-preview-device-mobile .stk-block-icon-label .block-editor-block-list__layout [data-type="stackable/icon"] {
@@ -7,4 +10,10 @@
 }
 .stk-preview-device-mobile .stk-block-icon-label .block-editor-block-list__layout [data-type="stackable/heading"] {
 	flex: 1 1 0;
+}
+// Heading container width is not limited anymore.
+.wp-block-stackable-icon-label.stk-block-icon-label {
+	.stk-inner-blocks.stk-block-content {
+		width: unset !important;
+	}
 }

--- a/src/block/icon-label/editor.scss
+++ b/src/block/icon-label/editor.scss
@@ -1,8 +1,5 @@
 .stk-block-icon-label [data-type="stackable/icon"] {
 	flex: 0 0 64px;
-	.stk-inner-blocks.stk-block-content {
-		max-width: unset !important;
-	}
 }
 // Icon label can collapse in mobile in the editor.
 .stk-preview-device-mobile .stk-block-icon-label .block-editor-block-list__layout [data-type="stackable/icon"] {

--- a/src/block/icon-label/editor.scss
+++ b/src/block/icon-label/editor.scss
@@ -11,6 +11,6 @@
 // Heading container width is not limited anymore.
 .wp-block-stackable-icon-label.stk-block-icon-label {
 	.stk-inner-blocks.stk-block-content {
-		width: unset !important;
+		max-width: unset !important;
 	}
 }

--- a/src/block/icon-label/style.js
+++ b/src/block/icon-label/style.js
@@ -63,6 +63,7 @@ export const IconLabelStyles = props => {
 
 	return (
 		<>
+			{ /* Alignment has been removed in 3.3.0, but retained here to prevent block errors */ }
 			<Alignment.Style { ...propsToPass } />
 			<BlockDiv.Style { ...propsToPass } />
 			<Column.Style { ...propsToPass } />
@@ -97,6 +98,7 @@ IconLabelStyles.Content = props => {
 
 	const stylesToRender = (
 		<>
+			{ /* Alignment has been removed in 3.3.0, but retained here to prevent block errors */ }
 			<Alignment.Style.Content { ...propsToPass } />
 			<BlockDiv.Style.Content { ...propsToPass } />
 			<Column.Style.Content { ...propsToPass } />

--- a/src/block/icon-label/style.scss
+++ b/src/block/icon-label/style.scss
@@ -19,4 +19,8 @@
 	.stk-row {
 		flex-wrap: nowrap;
 	}
+	// Inherit the width of the container
+	.wp-block-stackable-heading.stk-block-heading {
+		width: inherit;
+	}
 }


### PR DESCRIPTION
Fixes #2186. 

I saw that the container of the header in the front end did not inherit the size of the container so the alignment styling did not have any effect on it, so this pr also fixes that.  