### PR TITLE
Added conditional rendering to prevent mini nav from rendering if ListView is null. 

### DIFF
--- a/src/block-components/navigation-view/edit.js
+++ b/src/block-components/navigation-view/edit.js
@@ -80,6 +80,7 @@ export const Edit = () => {
 					--stk-inspector-navigation-view: ${ height }px;
 				}` : '' }
 			</style>
+			{ /** ListView is not available in WP 5.8.4 anmd below */ }
 			{ ListView && <ResizableBox
 				className={ classNames }
 				showHandle={ isOpen }

--- a/src/block-components/navigation-view/edit.js
+++ b/src/block-components/navigation-view/edit.js
@@ -80,7 +80,7 @@ export const Edit = () => {
 					--stk-inspector-navigation-view: ${ height }px;
 				}` : '' }
 			</style>
-			<ResizableBox
+			{ ListView && <ResizableBox
 				className={ classNames }
 				showHandle={ isOpen }
 				enable={ { top: true } }
@@ -115,7 +115,7 @@ export const Edit = () => {
 						/>
 					</div>
 				</PanelAdvancedSettings>
-			</ResizableBox>
+			</ResizableBox> }
 		</InspectorControls>
 	)
 }

--- a/src/block-components/navigation-view/edit.js
+++ b/src/block-components/navigation-view/edit.js
@@ -85,7 +85,7 @@ export const Edit = () => {
 					--stk-inspector-navigation-view: ${ height }px;
 				}` : '' }
 			</style>
-			{ <ResizableBox
+			<ResizableBox
 				className={ classNames }
 				showHandle={ isOpen }
 				enable={ { top: true } }
@@ -120,7 +120,7 @@ export const Edit = () => {
 						/>
 					</div>
 				</PanelAdvancedSettings>
-			</ResizableBox> }
+			</ResizableBox>
 		</InspectorControls>
 	)
 }

--- a/src/block-components/navigation-view/edit.js
+++ b/src/block-components/navigation-view/edit.js
@@ -60,6 +60,11 @@ export const Edit = () => {
 		}
 	} )
 
+	// ListView is not available in WP 5.8.4 and below, don't show it if it's not available.
+	if ( ! ListView ) {
+		return null
+	}
+
 	// Don't show if this is the only block.
 	if ( ! isSelected || isOnlyBlock ) {
 		return null
@@ -80,8 +85,7 @@ export const Edit = () => {
 					--stk-inspector-navigation-view: ${ height }px;
 				}` : '' }
 			</style>
-			{ /** ListView is not available in WP 5.8.4 anmd below */ }
-			{ ListView && <ResizableBox
+			{ <ResizableBox
 				className={ classNames }
 				showHandle={ isOpen }
 				enable={ { top: true } }


### PR DESCRIPTION
Fixes block errors seen in sites that use Stackable ver. 3.1.5 and WP ver 5.8.4 and below. 