### PR TITLE
Optimized CSS Rendering in the Editor

### DIFF
--- a/src/block-components/style/use-generated-css.js
+++ b/src/block-components/style/use-generated-css.js
@@ -3,8 +3,9 @@
  */
 import { useEffect } from '@wordpress/element'
 
+// TODO: remove all reference to useGeneratedCss across all the blocks.
 export const useGeneratedCss = attributes => {
-	useEffect( () => {
-		attributes.generatedCss = ''
-	}, [] )
+	// useEffect( () => {
+	// 	attributes.generatedCss = ''
+	// }, [] )
 }

--- a/src/block/button-group/style.js
+++ b/src/block/button-group/style.js
@@ -21,6 +21,7 @@ import { Style as StyleComponent } from '~stackable/components'
  */
 import { renderToString } from '@wordpress/element'
 import { useBlockEditContext } from '@wordpress/block-editor'
+import { withGeneratedCss } from '~stackable/higher-order'
 
 const flexGapOptionsEdit = {
 	selector: '.block-editor-block-list__layout',
@@ -72,7 +73,7 @@ const getStyleParams = () => {
 	]
 }
 
-export const ButtonGroupStyles = props => {
+export const ButtonGroupStyles = withGeneratedCss( props => {
 	const {
 		...propsToPass
 	} = props
@@ -106,7 +107,7 @@ export const ButtonGroupStyles = props => {
 			/>
 		</>
 	)
-}
+} )
 
 ButtonGroupStyles.defaultProps = {
 	isEditor: false,

--- a/src/block/button/style.js
+++ b/src/block/button/style.js
@@ -18,6 +18,7 @@ import { useBlockEditContext } from '@wordpress/block-editor'
  * WordPress dependencies
  */
 import { renderToString } from '@wordpress/element'
+import { withGeneratedCss } from '~stackable/higher-order'
 
 const buttonOptions = {
 	selector: '.stk-button',
@@ -28,7 +29,7 @@ const typographyOptions = {
 	hoverSelector: '.stk-button:hover .stk-button__inner-text',
 }
 
-export const ButtonStyles = props => {
+export const ButtonStyles = withGeneratedCss( props => {
 	const {
 		...propsToPass
 	} = props
@@ -51,7 +52,7 @@ export const ButtonStyles = props => {
 			<EffectsAnimations.Style { ...propsToPass } />
 		</>
 	)
-}
+} )
 
 ButtonStyles.defaultProps = {
 	isEditor: false,

--- a/src/block/column/style.js
+++ b/src/block/column/style.js
@@ -14,19 +14,16 @@ import {
 	EffectsAnimations,
 	Transform,
 } from '~stackable/block-components'
-import {
-	useBlockAttributes, useDeviceType,
-} from '~stackable/hooks'
+import { useBlockAttributes, useDeviceType } from '~stackable/hooks'
 import {
 	getUniqueBlockClass,
 	getStyles,
 	useStyles,
 } from '~stackable/util'
 import { Style as StyleComponent } from '~stackable/components'
-import {
-	Fragment, renderToString,
-} from '@wordpress/element'
+import { Fragment, renderToString } from '@wordpress/element'
 import { useBlockEditContext } from '@wordpress/block-editor'
+import { withGeneratedCss } from '~stackable/higher-order'
 
 const containerDivOptions = {
 	sizeSelector: '.stk-block-column__content',
@@ -70,7 +67,7 @@ const getStyleParams = () => {
 	]
 }
 
-const BlockStyles = props => {
+const BlockStyles = withGeneratedCss( props => {
 	const {
 		...propsToPass
 	} = props
@@ -104,7 +101,7 @@ const BlockStyles = props => {
 			/>
 		</Fragment>
 	)
-}
+} )
 
 BlockStyles.defaultProps = {
 	isEditor: false,

--- a/src/block/columns/style.js
+++ b/src/block/columns/style.js
@@ -11,9 +11,7 @@ import {
 	Transform,
 	ContentAlign,
 } from '~stackable/block-components'
-import {
-	useBlockAttributes, useDeviceType,
-} from '~stackable/hooks'
+import { useBlockAttributes, useDeviceType } from '~stackable/hooks'
 import {
 	getUniqueBlockClass, useStyles, getStyles,
 } from '~stackable/util'
@@ -25,12 +23,13 @@ import { Style as StyleComponent } from '~stackable/components'
 import { renderToString } from '@wordpress/element'
 import { useBlockEditContext } from '@wordpress/block-editor'
 import { applyFilters } from '@wordpress/hooks'
+import { withGeneratedCss } from '~stackable/higher-order'
 
 const alignmentOptions = {
 	editorSelectorCallback: getAttribute => `.stk--block-align-${ getAttribute( 'uniqueId' ) } > .block-editor-inner-blocks > .block-editor-block-list__layout`,
 }
 
-const BlockStyles = props => {
+const BlockStyles = withGeneratedCss( props => {
 	const {
 		...propsToPass
 	} = props
@@ -70,7 +69,7 @@ const BlockStyles = props => {
 			/>
 		</>
 	)
-}
+} )
 
 BlockStyles.defaultProps = {
 	isEditor: false,

--- a/src/block/heading/style.js
+++ b/src/block/heading/style.js
@@ -21,6 +21,7 @@ import { Style as StyleComponent } from '~stackable/components'
  */
 import { Fragment, renderToString } from '@wordpress/element'
 import { useBlockEditContext } from '@wordpress/block-editor'
+import { withGeneratedCss } from '~stackable/higher-order'
 
 const getStyleParams = () => {
 	return [
@@ -119,7 +120,7 @@ const getStyleParams = () => {
 	]
 }
 
-export const HeadingStyles = props => {
+export const HeadingStyles = withGeneratedCss( props => {
 	const {
 		...propsToPass
 	} = props
@@ -162,7 +163,7 @@ export const HeadingStyles = props => {
 			<EffectsAnimations.Style { ...propsToPass } />
 		</Fragment>
 	)
-}
+} )
 
 HeadingStyles.defaultProps = {
 	isEditor: false,

--- a/src/block/icon/style.js
+++ b/src/block/icon/style.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
 import {
 	Icon,
@@ -9,15 +9,14 @@ import {
 	EffectsAnimations,
 	Transform,
 } from '~stackable/block-components'
-import {
-	useBlockAttributes, useDeviceType,
-} from '~stackable/hooks'
-import {
-	getUniqueBlockClass,
-} from '~stackable/util'
-import {
-	Fragment, renderToString,
-} from '@wordpress/element'
+import { withGeneratedCss } from '~stackable/higher-order'
+import { useBlockAttributes, useDeviceType } from '~stackable/hooks'
+import { getUniqueBlockClass } from '~stackable/util'
+
+/**
+ * WordPress dependencies
+ */
+import { Fragment, renderToString } from '@wordpress/element'
 import { useBlockEditContext } from '@wordpress/block-editor'
 
 const iconStyleOptions = {
@@ -25,7 +24,7 @@ const iconStyleOptions = {
 	hoverSelector: '.stk--svg-wrapper:hover',
 }
 
-export const IconStyles = props => {
+export const IconStyles = withGeneratedCss( props => {
 	const {
 		...propsToPass
 	} = props
@@ -48,7 +47,7 @@ export const IconStyles = props => {
 			<Icon.Style { ...propsToPass } options={ iconStyleOptions } />
 		</Fragment>
 	)
-}
+} )
 
 IconStyles.defaultProps = {
 	isEditor: false,

--- a/src/block/text/style.js
+++ b/src/block/text/style.js
@@ -21,6 +21,7 @@ import { Style as StyleComponent } from '~stackable/components'
  */
 import { renderToString } from '@wordpress/element'
 import { useBlockEditContext } from '@wordpress/block-editor'
+import { withGeneratedCss } from '~stackable/higher-order'
 
 const typographyOptions = {
 	selector: '.stk-block-text__text',
@@ -45,7 +46,7 @@ const getStyleParams = () => {
 	]
 }
 
-export const TextStyles = props => {
+export const TextStyles = withGeneratedCss( props => {
 	const {
 		...propsToPass
 	} = props
@@ -76,7 +77,7 @@ export const TextStyles = props => {
 			<EffectsAnimations.Style { ...propsToPass } />
 		</>
 	)
-}
+} )
 
 TextStyles.defaultProps = {
 	isEditor: false,

--- a/src/higher-order/index.js
+++ b/src/higher-order/index.js
@@ -2,3 +2,4 @@
 export { default as withIsHovered } from './with-is-hovered'
 export { default as withVersion } from './with-version'
 export { default as withQueryLoopContext } from './with-query-loop-context'
+export { default as withGeneratedCss } from './with-generated-css'

--- a/src/higher-order/with-generated-css/index.js
+++ b/src/higher-order/with-generated-css/index.js
@@ -1,0 +1,53 @@
+/**
+ * Internal	dependencies
+ */
+import { useBlockAttributes } from '~stackable/hooks'
+
+/**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose'
+import { useSelect } from '@wordpress/data'
+import { useBlockEditContext } from '@wordpress/block-editor'
+
+const cachedBlockAttributes = {}
+
+const withGeneratedCss = createHigherOrderComponent(
+	WrappedComponent => props => {
+		const { clientId } = useBlockEditContext()
+		const attributes = useBlockAttributes( clientId )
+		const { getSelectedBlock } = useSelect( 'core/block-editor' )
+
+		// If the block is selected, don't use the generated CSS.
+		if ( attributes.generatedCss && getSelectedBlock()?.clientId === clientId ) {
+			delete cachedBlockAttributes[ clientId ]
+			attributes.generatedCss = ''
+		}
+
+		// If the generated CSS attribute is detected (this means the block
+		// previously exists already), then keep using those styles.
+		if ( attributes.generatedCss ) {
+			if ( ! cachedBlockAttributes[ clientId ] ) {
+				cachedBlockAttributes[ clientId ] = attributes
+				if ( attributes.generatedCss ) {
+					return <style>{ attributes.generatedCss }</style>
+				}
+			} else if ( cachedBlockAttributes[ clientId ] === attributes ) {
+				if ( attributes.generatedCss ) {
+					return <style>{ attributes.generatedCss }</style>
+				}
+			// If the attributes have changed, then start generating the css.
+			} else {
+				delete cachedBlockAttributes[ clientId ]
+				attributes.generatedCss = ''
+			}
+		}
+
+		return (
+			<WrappedComponent { ...props } />
+		)
+	},
+	'withGeneratedCss'
+)
+
+export default withGeneratedCss


### PR DESCRIPTION
CSS styles are computed depending on the block's attributes, these styles are computed based on the current attributes. This can be a tedious process and this is a big factor on performance.

This PR makes blocks use the previously generated (saved) CSS of the block - this should be faster because no styles are computed, the saved style is simply used. Then when the block's attribute changes, or when the block is selected, then the CSS will now be computed based on the attributes.