### PR TITLE
Prevents the column gap option from affecting inner blocks in the editor.

### DIFF
--- a/src/block/columns/editor.scss
+++ b/src/block/columns/editor.scss
@@ -25,6 +25,6 @@
 	max-width: none;
 }
 
-.stk-block-columns .block-editor-inner-blocks > .block-editor-block-list__layout {
+.stk-block-columns > .stk-block-content > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	column-gap: var(--stk-column-gap, 0px);
 }


### PR DESCRIPTION
Fixes #2248.