### PR TITLE
Margin-bottom is 0 in icon list so that themes' CSS wont affect it.

### DIFF
--- a/src/block/icon-list/style.scss
+++ b/src/block/icon-list/style.scss
@@ -36,11 +36,11 @@
 	margin-right: var(--stk-alignment-margin-right);
 }
 
-//Suggestion from blocksy, prevents.
-.wp-block-stackable-icon-list ul {
+// Prevents theme's css from affecting the list block.
+.stk-block-icon-list :is(ul, ol) {
 	margin-bottom: 0;
-}
 
-.wp-block-stackable-icon-list ul li:last-child {
-	margin-bottom: 0;
+	li:last-child {
+		margin-bottom: 0;
+	}
 }

--- a/src/block/icon-list/style.scss
+++ b/src/block/icon-list/style.scss
@@ -35,3 +35,12 @@
 	margin-left: var(--stk-alignment-margin-left);
 	margin-right: var(--stk-alignment-margin-right);
 }
+
+//Suggestion from blocksy, prevents.
+.wp-block-stackable-icon-list ul {
+	margin-bottom: 0;
+}
+
+.wp-block-stackable-icon-list ul li:last-child {
+	margin-bottom: 0;
+}

--- a/src/block/icon-list/style.scss
+++ b/src/block/icon-list/style.scss
@@ -36,7 +36,7 @@
 	margin-right: var(--stk-alignment-margin-right);
 }
 
-// Prevents theme's css from affecting the list block.
+// Prevents theme's css from affecting the icon list.
 .stk-block-icon-list :is(ul, ol) {
 	margin-bottom: 0;
 


### PR DESCRIPTION
Fixes #2253.