### PR TITLE
Added margin to the left of the color indicator to prevent it from misaligning in the color palette. 

### DIFF
--- a/src/components/color-palette-control/editor.scss
+++ b/src/components/color-palette-control/editor.scss
@@ -17,4 +17,7 @@
 	.component-color-indicator[style*="background: transparent"] {
 		background-image: linear-gradient(-45deg, #fff 48%, #f00 48%, #f00 52%, #fff 52%) !important;
 	}
+	.component-color-indicator {
+		margin-left: 5px;
+	}
 }

--- a/src/components/color-palette-control/editor.scss
+++ b/src/components/color-palette-control/editor.scss
@@ -18,6 +18,6 @@
 		background-image: linear-gradient(-45deg, #fff 48%, #f00 48%, #f00 52%, #fff 52%) !important;
 	}
 	.component-color-indicator {
-		margin-left: 5px;
+		margin-left: 8px;
 	}
 }


### PR DESCRIPTION
Fixes #2284.