### PR TITLE
Fix: removed paddings in toolbar stackable icons.

### DIFF
--- a/src/format-types/highlight/editor.scss
+++ b/src/format-types/highlight/editor.scss
@@ -1,5 +1,4 @@
 .block-editor-block-toolbar .stk-toolbar-button {
-	padding: 6px 12px !important;
 	&::before {
 		left: 8px !important;
 		right: 8px !important;


### PR DESCRIPTION
- Removes the extra paddings seen in WP 6.0. 
- Does not affect WP 5.9 Toolbar Icons. 