### PR TITLE
fix (i18n): missing i18n on strings in call-to-action/variations.js and some deprecated.js files

### DIFF
--- a/src/block/call-to-action/variations.js
+++ b/src/block/call-to-action/variations.js
@@ -43,7 +43,7 @@ const variations = applyFilters(
 				[ 'stackable/heading', { text: _x( 'Title for This Block', 'Heading placeholder', i18n ), textTag: 'h3' } ],
 				[ 'stackable/text', { text: _x( 'Description for this block. Use this space for describing your block. Any text will do. Description for this block. You can use this space for describing your block.', 'Content placeholder', i18n ) } ],
 				[ 'stackable/button-group', {}, [
-					[ 'stackable/button', { text: 'Button' } ],
+					[ 'stackable/button', { text: __( 'Button', i18n ) } ],
 				] ],
 			],
 			scope: [ 'block' ],
@@ -66,7 +66,7 @@ const variations = applyFilters(
 				[ 'stackable/heading', { text: _x( 'Title for This Block', 'Heading placeholder', i18n ), textTag: 'h3' } ],
 				[ 'stackable/text', { text: _x( 'Description for this block. Use this space for describing your block. Any text will do. Description for this block. You can use this space for describing your block.', 'Content placeholder', i18n ) } ],
 				[ 'stackable/button-group', {}, [
-					[ 'stackable/button', { text: 'Button' } ],
+					[ 'stackable/button', { text: __( 'Button', i18n ) } ],
 				] ],
 			],
 			scope: [ 'block' ],

--- a/src/deprecated/v2/block/button/deprecated.js
+++ b/src/deprecated/v2/block/button/deprecated.js
@@ -5,6 +5,7 @@ import {
 	DeprecatedButtonContent_1_15_5,
 } from '../../components/button-edit'
 import { range } from '~stackable/util'
+import { i18n } from 'stackable'
 
 /**
  * WordPress dependencies
@@ -35,7 +36,7 @@ const deprecatedSchema_1_15_5 = {
 	text: {
 		source: 'html',
 		selector: 'a span',
-		default: __( 'Button text' ),
+		default: __( 'Button text', i18n ),
 	},
 	align: {
 		type: 'string',
@@ -80,7 +81,7 @@ const deprecatedSchema_1_15_5 = {
 	text2: {
 		source: 'html',
 		selector: 'div:nth-of-type(2) .ugb-button span',
-		default: __( 'Button text' ),
+		default: __( 'Button text', i18n ),
 	},
 	color2: {
 		type: 'string',
@@ -118,7 +119,7 @@ const deprecatedSchema_1_15_5 = {
 	text3: {
 		source: 'html',
 		selector: 'div:nth-of-type(3) .ugb-button span',
-		default: __( 'Button text' ),
+		default: __( 'Button text', i18n ),
 	},
 	color3: {
 		type: 'string',

--- a/src/deprecated/v2/block/call-to-action/deprecated.js
+++ b/src/deprecated/v2/block/call-to-action/deprecated.js
@@ -5,6 +5,7 @@ import {
 	DeprecatedButtonContent_1_15_5,
 } from '../../components/button-edit'
 import { descriptionPlaceholder } from '~stackable/util'
+import { i18n } from 'stackable'
 
 /**
  * WordPress dependencies
@@ -140,7 +141,7 @@ export const deprecatedSchema_1_15_5 = {
 	ctaTitle: {
 		source: 'html',
 		selector: 'h3',
-		default: __( 'Title for This Block' ),
+		default: __( 'Title for This Block', i18n ),
 	},
 	bodyText: {
 		source: 'html',
@@ -150,7 +151,7 @@ export const deprecatedSchema_1_15_5 = {
 	buttonText: {
 		source: 'html',
 		selector: '.ugb-button span',
-		default: __( 'Button text' ),
+		default: __( 'Button text', i18n ),
 	},
 	buttonDesign: {
 		type: 'string',

--- a/src/deprecated/v2/block/count-up/deprecated.js
+++ b/src/deprecated/v2/block/count-up/deprecated.js
@@ -7,6 +7,7 @@ import { getFontFamily } from './deprecated-font'
  * External dependencies
  */
 import { range } from '~stackable/util'
+import { i18n } from 'stackable'
 
 /**
  * WordPress dependencies
@@ -189,22 +190,22 @@ export const deprecatedSchema_1_15_4 = {
 	title1: {
 		source: 'html',
 		selector: '.ugb-countup__item:nth-of-type(1) .ugb-countup__title',
-		default: __( 'Title' ),
+		default: __( 'Title', i18n ),
 	},
 	title2: {
 		source: 'html',
 		selector: '.ugb-countup__item:nth-of-type(2) .ugb-countup__title',
-		default: __( 'Title' ),
+		default: __( 'Title', i18n ),
 	},
 	title3: {
 		source: 'html',
 		selector: '.ugb-countup__item:nth-of-type(3) .ugb-countup__title',
-		default: __( 'Title' ),
+		default: __( 'Title', i18n ),
 	},
 	title4: {
 		source: 'html',
 		selector: '.ugb-countup__item:nth-of-type(4) .ugb-countup__title',
-		default: __( 'Title' ),
+		default: __( 'Title', i18n ),
 	},
 	countText1: {
 		source: 'html',
@@ -229,22 +230,22 @@ export const deprecatedSchema_1_15_4 = {
 	description1: {
 		source: 'html',
 		selector: '.ugb-countup__item:nth-of-type(1) .ugb-countup__description',
-		default: __( 'Description' ),
+		default: __( 'Description', i18n ),
 	},
 	description2: {
 		source: 'html',
 		selector: '.ugb-countup__item:nth-of-type(2) .ugb-countup__description',
-		default: __( 'Description' ),
+		default: __( 'Description', i18n ),
 	},
 	description3: {
 		source: 'html',
 		selector: '.ugb-countup__item:nth-of-type(3) .ugb-countup__description',
-		default: __( 'Description' ),
+		default: __( 'Description', i18n ),
 	},
 	description4: {
 		source: 'html',
 		selector: '.ugb-countup__item:nth-of-type(4) .ugb-countup__description',
-		default: __( 'Description' ),
+		default: __( 'Description', i18n ),
 	},
 	textColor: {
 		type: 'string',

--- a/src/deprecated/v2/block/number-box/deprecated.js
+++ b/src/deprecated/v2/block/number-box/deprecated.js
@@ -3,6 +3,7 @@
  */
 import { descriptionPlaceholder, isDarkColor } from '~stackable/util'
 import { range } from 'lodash'
+import { i18n } from 'stackable'
 
 /**
  * WordPress dependencies
@@ -31,17 +32,17 @@ const deprecatedSchema_1_15 = {
 	title1: {
 		source: 'html',
 		selector: '.ugb-number-box__item:nth-of-type(1) .ugb-number-box__title',
-		default: __( 'Title' ),
+		default: __( 'Title', i18n ),
 	},
 	title2: {
 		source: 'html',
 		selector: '.ugb-number-box__item:nth-of-type(2) .ugb-number-box__title',
-		default: __( 'Title' ),
+		default: __( 'Title', i18n ),
 	},
 	title3: {
 		source: 'html',
 		selector: '.ugb-number-box__item:nth-of-type(3) .ugb-number-box__title',
-		default: __( 'Title' ),
+		default: __( 'Title', i18n ),
 	},
 	description1: {
 		source: 'html',


### PR DESCRIPTION
fix (i18n): missing i18n on strings in call-to-action/variations.js and some deprecated.js files