### PR TITLE
fix (inspector-controls): added styling to prevent single column controls in inspector

### DIFF
--- a/src/editor.scss
+++ b/src/editor.scss
@@ -154,3 +154,12 @@ $block-joined: #{ join($blocks, (), $separator: comma) };
 .stk-block .components-card__body {
 	font-size: 12px;
 }
+
+.ugb-design-control .components-flex {
+	display: inline-block;
+}
+
+.ugb-columns-width-control .ugb-design-control .components-flex {
+	display: inline-block;
+	text-align: center;
+}

--- a/src/editor.scss
+++ b/src/editor.scss
@@ -155,10 +155,10 @@ $block-joined: #{ join($blocks, (), $separator: comma) };
 	font-size: 12px;
 }
 
+// Fix WP 6.1 makes the control into 1 column only.
 .ugb-design-control .components-flex {
 	display: inline-block;
 }
-
 .ugb-columns-width-control .ugb-design-control .components-flex {
 	display: inline-block;
 	text-align: center;


### PR DESCRIPTION
Fixes #2458, Fixes #2457, Fixes #2455, Fixes #2444 