### PR TITLE
fix (wp6.1): advance shadow popover now closes properly and does not overflow through the screen

### DIFF
--- a/src/components/shadow-control/index.js
+++ b/src/components/shadow-control/index.js
@@ -181,7 +181,7 @@ const ShadowFilterControl = props => {
 
 	return (
 		<Popover
-			position="top center"
+			placement="top-start"
 			className="shadow-control__popover"
 			anchorRect={ props.anchorRect }
 		>
@@ -255,7 +255,7 @@ const ShadowControl = props => {
 
 		document.body.addEventListener( 'mousedown', clickOutsideListener )
 		return () => document.body.removeEventListener( 'mousedown', clickOutsideListener )
-	}, [] )
+	}, [ isPopoverOpen ] )
 
 	useEffect( () => {
 		if ( isPopoverOpen ) {


### PR DESCRIPTION
Fixes #2468, Fixes #2456 