### PR TITLE
fix (wp6.1): added design library height and missing borders

### DIFF
--- a/src/deprecated/v2/components/modal-design-library/editor.scss
+++ b/src/deprecated/v2/components/modal-design-library/editor.scss
@@ -15,6 +15,8 @@
 	}
 	.components-modal__header {
 		margin: 0;
+		height: 58px;
+		border-bottom: 1px solid #ddd;
 	}
 	.ugb-modal-design-library__wrapper {
 		display: grid;

--- a/src/deprecated/v2/components/modal-design-library/editor.scss
+++ b/src/deprecated/v2/components/modal-design-library/editor.scss
@@ -12,6 +12,7 @@
 		padding: 0;
 		display: flex;
 		flex-direction: column;
+		margin-top: 57px;
 	}
 	.components-modal__header {
 		margin: 0;


### PR DESCRIPTION
Fixes #2495 