### PR TITLE
fix (wp6.1): removed redundant text when "Show button text labels" is on

### DIFF
--- a/src/plugins/design-library-button/design-library-button.js
+++ b/src/plugins/design-library-button/design-library-button.js
@@ -34,7 +34,6 @@ const DesignLibraryButton = () => {
 		<Button
 			onClick={ onClick }
 			className="ugb-insert-library-button"
-			label={ __( 'Open Design Library', i18n ) }
 			icon={ <SVGStackableIcon /> }
 		>{ __( 'Design Library', i18n ) }</Button>
 	)

--- a/src/plugins/design-library-button/editor.scss
+++ b/src/plugins/design-library-button/editor.scss
@@ -1,10 +1,3 @@
 .ugb-insert-library-button {
 	white-space: nowrap;
 }
-
-// Override content set by "Show button text labels"
-.ugb-insert-library-button__wrapper {
-	.ugb-insert-library-button.ugb-button-component.components-button.has-icon::after {
-		content: unset;
-	}
-}

--- a/src/plugins/design-library-button/editor.scss
+++ b/src/plugins/design-library-button/editor.scss
@@ -1,3 +1,10 @@
 .ugb-insert-library-button {
 	white-space: nowrap;
 }
+
+// Override content set by "Show button text labels"
+.ugb-insert-library-button__wrapper {
+	.ugb-insert-library-button.ugb-button-component.components-button.has-icon::after {
+		content: unset;
+	}
+}


### PR DESCRIPTION
Fixes #2486 