### PR TITLE
Fixed WordPress minimum required version number in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -194,7 +194,7 @@ Optimize your website’s performance, and get lightning fast page loading to ma
 
 = Minimum Requirements =
 
-You'll need WordPress version 5.8.3 or higher for this to work.
+You'll need WordPress version 6.0.3 or higher for this to work.
 
 == Frequently Asked Questions ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -194,7 +194,7 @@ Optimize your website’s performance, and get lightning fast page loading to ma
 
 = Minimum Requirements =
 
-You'll need WordPress version 6.0.3 or higher for this to work.
+You'll need WordPress version 5.9 or higher for this to work.
 
 == Frequently Asked Questions ==
 


### PR DESCRIPTION
Fixed WordPress minimum required version number in readme.txt

Please @bfintal check this PR of mine too #2472 

Also check this line

https://github.com/gambitph/Stackable/blob/6c384b86fc9cb24948cd5c04dcc2a120f845206c/plugin.php#L26

Thanks.