### PR TITLE
fix (wp6.1): adjusted the height of design library header and added borders

### DIFF
--- a/src/components/modal-design-library/editor.scss
+++ b/src/components/modal-design-library/editor.scss
@@ -13,6 +13,7 @@
 		&::after {
 			display: none;
 		}
+		margin-top: 57px;
 	}
 
 	.components-modal__content {
@@ -22,6 +23,8 @@
 	}
 	.components-modal__header {
 		margin: 0;
+		height: 58px;
+		border-bottom: 1px solid #ddd;
 	}
 	.ugb-modal-design-library__wrapper {
 		display: grid;


### PR DESCRIPTION
https://github.com/gambitph/Stackable/pull/2496 addresses the problem only if v2 backwards compatibility scripts are turned on. This pr addresses the problem even if that option is turned off 