### PR TITLE
Feature/image popup

### DIFF
--- a/.config/webpack.config.dev.js
+++ b/.config/webpack.config.dev.js
@@ -175,6 +175,7 @@ module.exports = [
 		'frontend_block_notification': path.resolve( __dirname, '../src/block/notification/frontend-notification.js' ),
 		'frontend_block_video_popup': path.resolve( __dirname, '../src/block/video-popup/frontend-video-popup.js' ),
 		'frontend_block_video_popup_button': path.resolve( __dirname, '../src/block/video-popup-button/frontend-video-popup-button.js' ),
+		'frontend_block_image_popup': path.resolve( __dirname, '../src/block/image-popup/frontend-image-popup.js' ),
 		'frontend_block_progress_circle': path.resolve( __dirname, '../src/block/progress-circle/frontend-progress-circle.js' ),
 		'frontend_block_progress_bar': path.resolve( __dirname, '../src/block/progress-bar/frontend-progress-bar.js' ),
 	},

--- a/.config/webpack.config.dev.js
+++ b/.config/webpack.config.dev.js
@@ -174,6 +174,7 @@ module.exports = [
 		'frontend_block_map': path.resolve( __dirname, '../src/block/map/frontend-map.js' ),
 		'frontend_block_notification': path.resolve( __dirname, '../src/block/notification/frontend-notification.js' ),
 		'frontend_block_video_popup': path.resolve( __dirname, '../src/block/video-popup/frontend-video-popup.js' ),
+		'frontend_block_video_popup_button': path.resolve( __dirname, '../src/block/video-popup-button/frontend-video-popup-button.js' ),
 		'frontend_block_progress_circle': path.resolve( __dirname, '../src/block/progress-circle/frontend-progress-circle.js' ),
 		'frontend_block_progress_bar': path.resolve( __dirname, '../src/block/progress-bar/frontend-progress-bar.js' ),
 	},

--- a/.config/webpack.config.prod.js
+++ b/.config/webpack.config.prod.js
@@ -160,6 +160,7 @@ module.exports = [
 		'frontend_block_notification': path.resolve( __dirname, '../src/block/notification/frontend-notification.js' ),
 		'frontend_block_video_popup': path.resolve( __dirname, '../src/block/video-popup/frontend-video-popup.js' ),
 		'frontend_block_video_popup_button': path.resolve( __dirname, '../src/block/video-popup-button/frontend-video-popup-button.js' ),
+		'frontend_block_image_popup': path.resolve( __dirname, '../src/block/image-popup/frontend-image-popup.js' ),
 		'frontend_block_progress_circle': path.resolve( __dirname, '../src/block/progress-circle/frontend-progress-circle.js' ),
 		'frontend_block_progress_bar': path.resolve( __dirname, '../src/block/progress-bar/frontend-progress-bar.js' ),
 	},

--- a/.config/webpack.config.prod.js
+++ b/.config/webpack.config.prod.js
@@ -159,6 +159,7 @@ module.exports = [
 		'frontend_block_map': path.resolve( __dirname, '../src/block/map/frontend-map.js' ),
 		'frontend_block_notification': path.resolve( __dirname, '../src/block/notification/frontend-notification.js' ),
 		'frontend_block_video_popup': path.resolve( __dirname, '../src/block/video-popup/frontend-video-popup.js' ),
+		'frontend_block_video_popup_button': path.resolve( __dirname, '../src/block/video-popup-button/frontend-video-popup-button.js' ),
 		'frontend_block_progress_circle': path.resolve( __dirname, '../src/block/progress-circle/frontend-progress-circle.js' ),
 		'frontend_block_progress_bar': path.resolve( __dirname, '../src/block/progress-bar/frontend-progress-bar.js' ),
 	},

--- a/plugin.php
+++ b/plugin.php
@@ -23,7 +23,7 @@ if ( function_exists( 'sugb_fs' ) ) {
 }
 
 defined( 'STACKABLE_SHOW_PRO_NOTICES' ) || define( 'STACKABLE_SHOW_PRO_NOTICES', true );
-defined( 'STACKABLE_BUILD' ) || define( 'STACKABLE_BUILD', 'premium' );
+defined( 'STACKABLE_BUILD' ) || define( 'STACKABLE_BUILD', 'free' );
 defined( 'STACKABLE_VERSION' ) || define( 'STACKABLE_VERSION', '3.6.1' );
 defined( 'STACKABLE_FILE' ) || define( 'STACKABLE_FILE', __FILE__ );
 defined( 'STACKABLE_I18N' ) || define( 'STACKABLE_I18N', 'stackable-ultimate-gutenberg-blocks' ); // Plugin slug.
@@ -171,6 +171,7 @@ require_once( plugin_dir_path( __FILE__ ) . 'src/block/count-up/index.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/block/expand/index.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/block/notification/index.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/block/video-popup/index.php' );
+require_once( plugin_dir_path( __FILE__ ) . 'src/block/video-popup-button/index.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/block/table-of-contents/index.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/block/map/index.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/block/progress-bar/index.php' );

--- a/plugin.php
+++ b/plugin.php
@@ -172,6 +172,7 @@ require_once( plugin_dir_path( __FILE__ ) . 'src/block/expand/index.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/block/notification/index.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/block/video-popup/index.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/block/video-popup-button/index.php' );
+require_once( plugin_dir_path( __FILE__ ) . 'src/block/image-popup/index.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/block/table-of-contents/index.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/block/map/index.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/block/progress-bar/index.php' );

--- a/readme.txt
+++ b/readme.txt
@@ -55,6 +55,7 @@ Special Blocks
 - Image Box Block — [View Block](https://wpstackable.com/image-box-block/?utm_source=wp-repo&utm_campaign=readme&utm_medium=link)
 - Video Popup Block — [View Block](https://wpstackable.com/video-popup-block/?utm_source=wp-repo&utm_campaign=readme&utm_medium=link)
 - Video Popup Button Block
+- Image Popup Block
 - Progress Circle Block — [View Block](https://wpstackable.com/progress-circle-block/?utm_source=wp-repo&utm_campaign=readme&utm_medium=link)
 - Progress Bar Block — [View Block](https://wpstackable.com/progress-bar-block/?utm_source=wp-repo&utm_campaign=readme&utm_medium=link)
 - Accordion Block — [View Block](https://wpstackable.com/accordion-block/?utm_source=wp-repo&utm_campaign=readme&utm_medium=link)

--- a/readme.txt
+++ b/readme.txt
@@ -54,6 +54,7 @@ Special Blocks
 - Posts Block — [View Block](https://wpstackable.com/blog-posts-block/?utm_source=wp-repo&utm_campaign=readme&utm_medium=link)
 - Image Box Block — [View Block](https://wpstackable.com/image-box-block/?utm_source=wp-repo&utm_campaign=readme&utm_medium=link)
 - Video Popup Block — [View Block](https://wpstackable.com/video-popup-block/?utm_source=wp-repo&utm_campaign=readme&utm_medium=link)
+- Video Popup Button Block
 - Progress Circle Block — [View Block](https://wpstackable.com/progress-circle-block/?utm_source=wp-repo&utm_campaign=readme&utm_medium=link)
 - Progress Bar Block — [View Block](https://wpstackable.com/progress-bar-block/?utm_source=wp-repo&utm_campaign=readme&utm_medium=link)
 - Accordion Block — [View Block](https://wpstackable.com/accordion-block/?utm_source=wp-repo&utm_campaign=readme&utm_medium=link)

--- a/src/block/image-popup/block.json
+++ b/src/block/image-popup/block.json
@@ -1,0 +1,15 @@
+{
+	"apiVersion": 2,
+	"name": "stackable/image-popup",
+	"title": "Image Popup",
+	"description": "Display a thumbnail that your users can click to display an image full-screen.",
+	"category": "stackable",
+	"usesContext": [ "postId", "postType", "queryId" ],
+	"keywords": [
+		"image",
+		"modal"
+	],
+	"textdomain": "stackable-ultimate-gutenberg-blocks",
+	"stk-type": "special",
+	"stk-demo": "https://wpstackable.com/image-popup-block/?utm_source=welcome&utm_medium=settings&utm_campaign=view_demo&utm_content=demolink"
+}

--- a/src/block/image-popup/edit.js
+++ b/src/block/image-popup/edit.js
@@ -1,0 +1,166 @@
+/**
+ * Internal dependencies
+ */
+import { IconLabelStyles } from './style'
+
+/**
+ * External dependencies
+ */
+import { version as VERSION, i18n } from 'stackable'
+import classnames from 'classnames'
+import {
+	InspectorTabs,
+	InspectorStyleControls,
+	PanelAdvancedSettings,
+	ImageControl2,
+	AdvancedTextControl,
+	InspectorBottomTip,
+} from '~stackable/components'
+import {
+	BlockDiv,
+	useGeneratedCss,
+	MarginBottom,
+	getRowClasses,
+	Alignment,
+	getAlignmentClasses,
+	Advanced,
+	CustomCSS,
+	Responsive,
+	CustomAttributes,
+	EffectsAnimations,
+	ConditionalDisplay,
+	Transform,
+} from '~stackable/block-components'
+import {
+	withBlockAttributeContext, withBlockWrapper, withQueryLoopContext,
+} from '~stackable/higher-order'
+
+/**
+ * WordPress dependencies
+ */
+import { compose } from '@wordpress/compose'
+import { InnerBlocks } from '@wordpress/block-editor'
+import { Fragment } from '@wordpress/element'
+import { __ } from '@wordpress/i18n'
+import { addFilter } from '@wordpress/hooks'
+
+export const defaultIcon = '<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="expand-alt" class="svg-inline--fa fa-expand-alt fa-w-14" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" width="32" height="32"><path fill="currentColor" d="M212.686 315.314L120 408l32.922 31.029c15.12 15.12 4.412 40.971-16.97 40.971h-112C10.697 480 0 469.255 0 456V344c0-21.382 25.803-32.09 40.922-16.971L72 360l92.686-92.686c6.248-6.248 16.379-6.248 22.627 0l25.373 25.373c6.249 6.248 6.249 16.378 0 22.627zm22.628-118.628L328 104l-32.922-31.029C279.958 57.851 290.666 32 312.048 32h112C437.303 32 448 42.745 448 56v112c0 21.382-25.803 32.09-40.922 16.971L376 152l-92.686 92.686c-6.248 6.248-16.379 6.248-22.627 0l-25.373-25.373c-6.249-6.248-6.249-16.378 0-22.627z"></path></svg>'
+
+const TEMPLATE = [
+	[ 'stackable/icon', {
+		contentAlign: 'center', icon: defaultIcon, linkHasLink: false,
+	} ],
+	[ 'stackable/image', { enableHandles: false } ],
+]
+
+const Edit = props => {
+	const {
+		className,
+		attributes,
+		setAttributes,
+	} = props
+
+	useGeneratedCss( props.attributes )
+
+	const rowClass = getRowClasses( attributes )
+	const blockAlignmentClass = getAlignmentClasses( attributes )
+
+	const blockClassNames = classnames( [
+		className,
+		'stk-block-image-popup',
+		rowClass,
+	] )
+
+	const contentClassNames = classnames( [
+		'stk-inner-blocks',
+		blockAlignmentClass,
+		'stk-block-content',
+		'stk-hover-parent',
+	] )
+
+	return (
+		<Fragment>
+			<InspectorTabs />
+
+			<Alignment.InspectorControls />
+			<BlockDiv.InspectorControls />
+			<InspectorStyleControls>
+				<PanelAdvancedSettings
+					title={ __( 'General', i18n ) }
+					id="general"
+					initialOpen={ true }
+				>
+					<ImageControl2
+						isDynamic={ false }
+						label={ __( 'Popup Option #1: Upload Image', i18n ) }
+						onRemove={ () => setAttributes( {
+							imageLink: '',
+							imageId: '',
+						} ) }
+						onChange={ media => {
+							setAttributes( {
+								imageLink: media.url,
+								imageId: media.url,
+							} )
+						} }
+						imageId={ attributes.imageId }
+						imageURL={ attributes.imageLink }
+						allowedTypes={ [ 'image' ] }
+					/>
+					<AdvancedTextControl
+						label={ __( 'Popup Option #2: Image URL', i18n ) }
+						isDynamic={ true }
+						isFormatType={ false }
+						placeholder="https://"
+						value={ attributes.imageLink }
+						onChange={ imageLink => setAttributes( {
+							imageLink,
+							imageId: imageLink,
+						} ) }
+					/>
+				</PanelAdvancedSettings>
+
+			</InspectorStyleControls>
+			<Advanced.InspectorControls />
+			<Transform.InspectorControls />
+			<EffectsAnimations.InspectorControls />
+			<CustomAttributes.InspectorControls />
+			<CustomCSS.InspectorControls mainBlockClass="stk-block-image-popup" />
+			<Responsive.InspectorControls />
+			<ConditionalDisplay.InspectorControls />
+
+			<InspectorStyleControls>
+				<InspectorBottomTip />
+			</InspectorStyleControls>
+
+			<IconLabelStyles version={ VERSION } />
+			<CustomCSS mainBlockClass="stk-block-image-popup" />
+
+			<BlockDiv className={ blockClassNames }>
+				<div className={ contentClassNames }>
+					<InnerBlocks
+						template={ TEMPLATE }
+						templateLock="all"
+					/>
+				</div>
+			</BlockDiv>
+			<MarginBottom />
+		</Fragment>
+	)
+}
+
+export default compose(
+	withBlockWrapper,
+	withQueryLoopContext,
+	withBlockAttributeContext,
+)( Edit )
+
+// Disable bottom margins for child blocks.
+addFilter( 'stackable.edit.margin-bottom.enable-handlers', 'stackable/image-popup', ( enabled, parentBlock ) => {
+	return parentBlock?.name === 'stackable/image-popup' ? false : enabled
+} )
+
+// Disable links for image block.
+addFilter( 'stackable.edit.image.enable-link', 'stackable/image-popup', ( enabled, parentBlock ) => {
+	return parentBlock?.name === 'stackable/image-popup' ? false : enabled
+} )

--- a/src/block/image-popup/editor.scss
+++ b/src/block/image-popup/editor.scss
@@ -1,0 +1,30 @@
+.stk-block-image-popup {
+	.block-editor-block-list__layout {
+		display: grid !important;
+		[data-block] {
+			grid-column: 1 / 2;
+			grid-row: 1 / 2;
+			margin: 0;
+			display: flex;
+			justify-content: center;
+			align-items: center;
+		}
+	}
+	[data-type="stackable/icon"] {
+		z-index: 2 !important;
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		width: auto !important;
+		transform: translate(-50%, -50%);
+	}
+	// Lower the image dimension overlay.
+	[data-type="stackable/image"] {
+		.stk-img-resizer-tooltip {
+			top: 80%;
+		}
+	}
+}
+.editor-styles-wrapper .stk-block-image-popup [data-block] {
+	max-width: none;
+}

--- a/src/block/image-popup/example.js
+++ b/src/block/image-popup/example.js
@@ -1,0 +1,13 @@
+export default {
+	attributes: {
+		uniqueId: '436a2b2', hasBackground: false, hasBorders: false, effectAnimationOut: {}, effectAnimationIn: {}, customAttributes: [], hideDesktop: false, hideTablet: false, hideMobile: false, displayCondition: {}, blockBackgroundCustomSizeUnit: '%', blockBackgroundCustomSizeUnitTablet: '%', blockBackgroundCustomSizeUnitMobile: '%',
+	}, innerBlocks: [ {
+		name: 'stackable/icon', attributes: {
+			uniqueId: '4e1adcf', hasBackground: false, hasBorders: false, contentAlign: 'center', effectAnimationOut: {}, effectAnimationIn: {}, customAttributes: [], hideDesktop: false, hideTablet: false, hideMobile: false, displayCondition: {}, icon: '<svg data-prefix="fas" data-icon="play" class="svg-inline--fa fa-play fa-w-14" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" aria-hidden="true"><path fill="currentColor" d="M424.4 214.7L72.4 6.6C43.8-10.3 0 6.1 0 47.9V464c0 37.5 40.7 60.1 72.4 41.3l352-208c31.4-18.5 31.5-64.1 0-82.6z"></path></svg>', showBackgroundShape: false, linkHasLink: false, linkNewTab: false, linkHasTitle: true, blockBackgroundCustomSizeUnit: '%', blockBackgroundCustomSizeUnitTablet: '%', blockBackgroundCustomSizeUnitMobile: '%', iconColor1: '#FFFFFF',
+		}, innerBlocks: [],
+	}, {
+		name: 'stackable/image', attributes: {
+			uniqueId: 'd4394aa', hasBackground: false, hasBorders: false, imageShow: true, imageUrl: 'https://source.unsplash.com/800x500/?sea,coast,water', imageSize: 'full', imageShapeStretch: true, effectAnimationOut: {}, effectAnimationIn: {}, customAttributes: [], hideDesktop: false, hideTablet: false, hideMobile: false, displayCondition: {}, blockLinkHasLink: true, blockLinkNewTab: false, blockLinkHasTitle: true, blockBackgroundCustomSizeUnit: '%', blockBackgroundCustomSizeUnitTablet: '%', blockBackgroundCustomSizeUnitMobile: '%', imageWidthUnit: '%', imageWidthUnitTablet: '%', imageWidthUnitMobile: '%',
+		}, innerBlocks: [],
+	} ],
+}

--- a/src/block/image-popup/frontend-image-popup.js
+++ b/src/block/image-popup/frontend-image-popup.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import BigPicture from 'bigpicture'
+
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready'
+
+class StackableImagePopup {
+	init = () => {
+		const els = document.querySelectorAll( '.stk-block-image-popup' )
+
+		const openimage = el => {
+			if ( BigPicture ) {
+				const args = {
+					el,
+					noLoader: true,
+				}
+
+				const imageID = el.getAttribute( 'data-image' )
+				if ( imageID.match( /^https?:/ ) ) {
+					args.imgSrc = imageID
+				}
+
+				BigPicture( args )
+			}
+		}
+		els.forEach( el => {
+			el.querySelector( 'button' ).addEventListener( 'click', ev => {
+				ev.preventDefault()
+				openimage( el )
+			} )
+		} )
+	}
+}
+
+window.stackableImagePopup = new StackableImagePopup()
+domReady( window.stackableImagePopup.init )

--- a/src/block/image-popup/index.js
+++ b/src/block/image-popup/index.js
@@ -1,0 +1,31 @@
+/**
+ * BLOCK: Icon Label Block
+ */
+/**
+ * External dependencies
+ */
+import { VideoPopupIcon } from '~stackable/icons'
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit'
+import save from './save'
+import schema from './schema'
+import metadata from './block.json'
+import example from './example'
+
+export const settings = {
+	...metadata,
+	icon: VideoPopupIcon,
+	attributes: schema,
+	supports: {
+		anchor: true,
+		align: true,
+		stkAlign: true,
+	},
+	example,
+
+	edit,
+	save,
+}

--- a/src/block/image-popup/index.php
+++ b/src/block/image-popup/index.php
@@ -1,0 +1,21 @@
+<?php
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'stackable_load_imagepopup_frontend_script' ) ) {
+	function stackable_load_imagepopup_frontend_script() {
+		if ( ! is_admin() ) {
+			wp_enqueue_script(
+				'stk-frontend-image-popup',
+				plugins_url( 'dist/frontend_block_image_popup.js', STACKABLE_FILE ),
+				array(),
+				STACKABLE_VERSION,
+				true
+			);
+		}
+	}
+	add_action( 'stackable/image-popup/enqueue_scripts', 'stackable_load_imagepopup_frontend_script' );
+}

--- a/src/block/image-popup/save.js
+++ b/src/block/image-popup/save.js
@@ -1,0 +1,68 @@
+/**
+ * Internal dependencies
+ */
+import { IconLabelStyles } from './style'
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames'
+import { withVersion } from '~stackable/higher-order'
+import { i18n, version as VERSION } from 'stackable'
+import {
+	BlockDiv,
+	CustomCSS,
+	getAlignmentClasses,
+	getResponsiveClasses,
+	getRowClasses,
+} from '~stackable/block-components'
+
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor'
+import { compose } from '@wordpress/compose'
+import { __ } from '@wordpress/i18n'
+
+export const Save = props => {
+	const {
+		attributes, className,
+	} = props
+
+	const rowClass = getRowClasses( attributes )
+	const blockAlignmentClass = getAlignmentClasses( attributes )
+	const responsiveClass = getResponsiveClasses( attributes )
+
+	const blockClassNames = classnames( [
+		className,
+		'stk-block-image-popup',
+		responsiveClass,
+	] )
+
+	const contentClassNames = classnames( [
+		'stk-block-image-popup__overlay',
+		rowClass,
+		'stk-inner-blocks',
+		blockAlignmentClass,
+		'stk-block-content',
+		'stk-hover-parent',
+	] )
+
+	return (
+		<BlockDiv.Content
+			className={ blockClassNames }
+			attributes={ attributes }
+			data-image={ attributes.imageLink }
+		>
+			<IconLabelStyles.Content version={ props.version } attributes={ attributes } />
+			<CustomCSS.Content attributes={ attributes } />
+			<button className={ contentClassNames } aria-label={ attributes.ariaLabel || __( 'Expand Image', i18n ) }>
+				<InnerBlocks.Content />
+			</button>
+		</BlockDiv.Content>
+	)
+}
+
+export default compose(
+	withVersion( VERSION )
+)( Save )

--- a/src/block/image-popup/schema.js
+++ b/src/block/image-popup/schema.js
@@ -1,0 +1,61 @@
+import {
+	Advanced,
+	Alignment,
+	BlockDiv,
+	Style,
+	ConditionalDisplay,
+	CustomAttributes,
+	CustomCSS,
+	EffectsAnimations,
+	MarginBottom,
+	Responsive,
+	Row,
+	Transform,
+} from '~stackable/block-components'
+import { AttributeObject } from '~stackable/util'
+import { version as VERSION } from 'stackable'
+
+export const attributes = ( version = VERSION ) => {
+	const attrObject = new AttributeObject()
+
+	BlockDiv.addAttributes( attrObject )
+	Style.addAttributes( attrObject )
+	MarginBottom.addAttributes( attrObject )
+	Row.addAttributes( attrObject )
+	Advanced.addAttributes( attrObject )
+	Transform.addAttributes( attrObject )
+	Alignment.addAttributes( attrObject )
+	EffectsAnimations.addAttributes( attrObject )
+	CustomAttributes.addAttributes( attrObject )
+	CustomCSS.addAttributes( attrObject )
+	Responsive.addAttributes( attrObject )
+	ConditionalDisplay.addAttributes( attrObject )
+	attrObject.add( {
+		attributes: {
+			imageLink: {
+				type: 'string',
+				default: '',
+			},
+			imageId: {
+				type: 'string',
+				source: 'attribute',
+				selector: '[data-image]',
+				attribute: 'data-image',
+				default: '',
+			},
+			ariaLabel: {
+				type: 'string',
+				source: 'attribute',
+				selector: 'button',
+				attribute: 'aria-label',
+				default: '',
+			},
+		},
+		versionAdded: '3.0.0',
+		versionDeprecated: '',
+	} )
+
+	return attrObject.getMerged( version )
+}
+
+export default attributes( VERSION )

--- a/src/block/image-popup/style.js
+++ b/src/block/image-popup/style.js
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import {
+	Advanced,
+	Alignment,
+	BlockDiv,
+	Column,
+	EffectsAnimations,
+	Transform,
+} from '~stackable/block-components'
+import { Style as StyleComponent } from '~stackable/components'
+import {
+	getUniqueBlockClass, useStyles, getStyles,
+} from '~stackable/util'
+
+/**
+ * WordPress dependencies
+ */
+import { memo, renderToString } from '@wordpress/element'
+
+const getStyleParams = () => {
+	return [
+		{
+			selector: '.stk-block-icon',
+			attrName: 'iconGap',
+			styleRule: 'flexBasis',
+			format: '%spx',
+		},
+	]
+}
+
+export const IconLabelStyles = memo( props => {
+	const styles = useStyles( getStyleParams() )
+
+	return (
+		<>
+			<Alignment.Style { ...props } />
+			<BlockDiv.Style { ...props } />
+			<Column.Style { ...props } />
+			<Advanced.Style { ...props } />
+			<Transform.Style { ...props } />
+			<EffectsAnimations.Style { ...props } />
+			<StyleComponent
+				styles={ styles }
+				versionAdded="3.0.0"
+				versionDeprecated=""
+				{ ...props }
+			/>
+		</>
+	)
+} )
+
+IconLabelStyles.defaultProps = {
+	isEditor: false,
+}
+
+IconLabelStyles.Content = props => {
+	const {
+		...propsToPass
+	} = props
+
+	if ( props.attributes.generatedCss ) {
+		return <style>{ props.attributes.generatedCss }</style>
+	}
+
+	propsToPass.blockUniqueClassName = getUniqueBlockClass( props.attributes.uniqueId )
+	const styles = getStyles( propsToPass.attributes, getStyleParams() )
+
+	const stylesToRender = (
+		<>
+			<Alignment.Style.Content { ...propsToPass } />
+			<BlockDiv.Style.Content { ...propsToPass } />
+			<Column.Style.Content { ...propsToPass } />
+			<EffectsAnimations.Style.Content { ...propsToPass } />
+			<Advanced.Style.Content { ...propsToPass } />
+			<Transform.Style.Content { ...propsToPass } />
+			<StyleComponent.Content
+				styles={ styles }
+				versionAdded="3.0.0"
+				versionDeprecated=""
+				{ ...propsToPass }
+			/>
+		</>
+	)
+
+	return renderToString( stylesToRender ) ? <style>{ stylesToRender }</style> : null
+}
+
+IconLabelStyles.Content.defaultProps = {
+	attributes: {},
+}

--- a/src/block/image-popup/style.scss
+++ b/src/block/image-popup/style.scss
@@ -1,0 +1,31 @@
+.stk-block-image-popup {
+	.stk-inner-blocks {
+		display: grid;
+		max-width: none !important;
+		.stk-block {
+			grid-column: 1 / 2;
+			grid-row: 1 / 2;
+			margin: 0;
+		}
+	}
+	.stk-block-icon {
+		justify-self: center;
+		align-self: center;
+		width: auto;
+		z-index: 2;
+	}
+	.stk-img-wrapper {
+		height: 100%;
+	}
+	:is(.stk-block-icon, .stk-block-image) {
+		--stk-block-margin-bottom: 0;
+	}
+}
+.stk-block-image-popup__overlay {
+	all: unset;
+	cursor: pointer;
+	margin: 0 auto;
+	display: grid;
+	width: 100% !important;
+	background-color: transparent !important;
+}

--- a/src/block/video-popup-button/block.json
+++ b/src/block/video-popup-button/block.json
@@ -1,0 +1,16 @@
+{
+	"apiVersion": 2,
+	"name": "stackable/video-popup-button",
+	"title": "Video Popup Button",
+	"description": "Display a button that your users can click to play a video full-screen.",
+	"category": "stackable",
+	"usesContext": [ "postId", "postType", "queryId" ],
+	"keywords": [
+		"YouTube",
+		"Vimeo",
+		"Embed Mp4"
+	],
+	"textdomain": "stackable-ultimate-gutenberg-blocks",
+	"stk-type": "special",
+	"stk-demo": "https://wpstackable.com/video-popup-block/?utm_source=welcome&utm_medium=settings&utm_campaign=view_demo&utm_content=demolink"
+}

--- a/src/block/video-popup-button/edit.js
+++ b/src/block/video-popup-button/edit.js
@@ -1,0 +1,168 @@
+/**
+ * Internal dependencies
+ */
+import { IconLabelStyles } from './style'
+
+/**
+ * External dependencies
+ */
+import { version as VERSION, i18n } from 'stackable'
+import classnames from 'classnames'
+import {
+	InspectorTabs,
+	InspectorStyleControls,
+	PanelAdvancedSettings,
+	ImageControl2,
+	AdvancedTextControl,
+	InspectorBottomTip,
+} from '~stackable/components'
+import {
+	BlockDiv,
+	useGeneratedCss,
+	MarginBottom,
+	getRowClasses,
+	Alignment,
+	getAlignmentClasses,
+	Advanced,
+	CustomCSS,
+	Responsive,
+	CustomAttributes,
+	EffectsAnimations,
+	ConditionalDisplay,
+	Transform,
+} from '~stackable/block-components'
+import { getVideoProviderFromURL, urlIsVideo } from '~stackable/util'
+import {
+	withBlockAttributeContext, withBlockWrapper, withQueryLoopContext,
+} from '~stackable/higher-order'
+
+/**
+ * WordPress dependencies
+ */
+import { compose } from '@wordpress/compose'
+import { InnerBlocks } from '@wordpress/block-editor'
+import { Fragment } from '@wordpress/element'
+import { __ } from '@wordpress/i18n'
+import { addFilter } from '@wordpress/hooks'
+
+export const defaultIcon = '<svg data-prefix="fas" data-icon="play" class="svg-inline--fa fa-play fa-w-14" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" aria-hidden="true"><path fill="currentColor" d="M424.4 214.7L72.4 6.6C43.8-10.3 0 6.1 0 47.9V464c0 37.5 40.7 60.1 72.4 41.3l352-208c31.4-18.5 31.5-64.1 0-82.6z"></path></svg>'
+
+const TEMPLATE = [
+	[ 'core/buttons', {}
+		[ 'core/button', { url: '#', text: 'Watch Video' } ],
+	],
+]
+
+const Edit = props => {
+	const {
+		className,
+		attributes,
+		setAttributes,
+	} = props
+
+	useGeneratedCss( props.attributes )
+
+	const rowClass = getRowClasses( attributes )
+	const blockAlignmentClass = getAlignmentClasses( attributes )
+
+	const blockClassNames = classnames( [
+		className,
+		'stk-block-video-popup-button',
+		rowClass,
+	] )
+
+	const contentClassNames = classnames( [
+		'stk-inner-blocks',
+		blockAlignmentClass,
+		'stk-block-content',
+		'stk-hover-parent',
+	] )
+
+	return (
+		<Fragment>
+			<InspectorTabs />
+
+			<Alignment.InspectorControls />
+			<BlockDiv.InspectorControls />
+			<InspectorStyleControls>
+				<PanelAdvancedSettings
+					title={ __( 'General', i18n ) }
+					id="general"
+					initialOpen={ true }
+				>
+					<ImageControl2
+						isDynamic={ false }
+						label={ __( 'Popup Option #1: Upload Video', i18n ) }
+						help={ __( 'Use .mp4 format for videos', i18n ) }
+						onRemove={ () => setAttributes( {
+							videoLink: '',
+							videoId: '',
+						} ) }
+						onChange={ media => {
+							setAttributes( {
+								videoLink: media.url,
+								videoId: media.url,
+							} )
+						} }
+						imageId={ urlIsVideo( attributes.videoLink ) ? attributes.videoId : '' }
+						imageURL={ urlIsVideo( attributes.videoLink ) ? attributes.videoLink : '' }
+						allowedTypes={ [ 'video' ] }
+					/>
+					<AdvancedTextControl
+						label={ __( 'Popup Option #2: Video URL', i18n ) }
+						help={ __( 'Paste a Youtube / Vimeo URL', i18n ) }
+						isDynamic={ true }
+						isFormatType={ false }
+						placeholder="https://"
+						value={ ! urlIsVideo( attributes.videoLink ) ? attributes.videoLink : '' }
+						onChange={ videoLink => setAttributes( {
+							videoLink,
+							videoId: getVideoProviderFromURL( videoLink ).id,
+						} ) }
+					/>
+				</PanelAdvancedSettings>
+
+			</InspectorStyleControls>
+			<Advanced.InspectorControls />
+			<Transform.InspectorControls />
+			<EffectsAnimations.InspectorControls />
+			<CustomAttributes.InspectorControls />
+			<CustomCSS.InspectorControls mainBlockClass="stk-block-video-popup-button" />
+			<Responsive.InspectorControls />
+			<ConditionalDisplay.InspectorControls />
+
+			<InspectorStyleControls>
+				<InspectorBottomTip />
+			</InspectorStyleControls>
+
+			<IconLabelStyles version={ VERSION } />
+			<CustomCSS mainBlockClass="stk-block-video-popup-button" />
+
+			<BlockDiv className={ blockClassNames }>
+				<div className={ contentClassNames }>
+					<InnerBlocks
+						template={ TEMPLATE }
+						templateLock="all"
+					/>
+				</div>
+			</BlockDiv>
+			<MarginBottom />
+		</Fragment>
+	)
+}
+
+export default compose(
+	withBlockWrapper,
+	withQueryLoopContext,
+	withBlockAttributeContext,
+)( Edit )
+
+// Disable bottom margins for child blocks.
+addFilter( 'stackable.edit.margin-bottom.enable-handlers', 'stackable/video-popup-button', ( enabled, parentBlock ) => {
+	return parentBlock?.name === 'stackable/video-popup-button' ? false : enabled
+} )
+
+// Disable links for image block.
+addFilter( 'stackable.edit.image.enable-link', 'stackable/video-popup-button', ( enabled, parentBlock ) => {
+	return parentBlock?.name === 'stackable/video-popup-button' ? false : enabled
+} )

--- a/src/block/video-popup-button/editor.scss
+++ b/src/block/video-popup-button/editor.scss
@@ -1,0 +1,29 @@
+.stk-block-video-popup-button {
+	.block-editor-block-list__layout {
+		display: grid !important;
+		[data-block] {
+			grid-column: 1 / 2;
+			grid-row: 1 / 2;
+			margin: 0;
+			display: flex;
+			align-items: center;
+		}
+	}
+	[data-type="stackable/icon"] {
+		z-index: 2 !important;
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		width: auto !important;
+		transform: translate(-50%, -50%);
+	}
+	// Lower the image dimension overlay.
+	[data-type="stackable/image"] {
+		.stk-img-resizer-tooltip {
+			top: 80%;
+		}
+	}
+}
+.editor-styles-wrapper .stk-block-video-popup-button [data-block] {
+	max-width: none;
+}

--- a/src/block/video-popup-button/example.js
+++ b/src/block/video-popup-button/example.js
@@ -1,0 +1,13 @@
+export default {
+	attributes: {
+		uniqueId: '436a2b2', hasBackground: false, hasBorders: false, effectAnimationOut: {}, effectAnimationIn: {}, customAttributes: [], hideDesktop: false, hideTablet: false, hideMobile: false, displayCondition: {}, blockBackgroundCustomSizeUnit: '%', blockBackgroundCustomSizeUnitTablet: '%', blockBackgroundCustomSizeUnitMobile: '%',
+	}, innerBlocks: [ {
+		name: 'stackable/icon', attributes: {
+			uniqueId: '4e1adcf', hasBackground: false, hasBorders: false, contentAlign: 'center', effectAnimationOut: {}, effectAnimationIn: {}, customAttributes: [], hideDesktop: false, hideTablet: false, hideMobile: false, displayCondition: {}, icon: '<svg data-prefix="fas" data-icon="play" class="svg-inline--fa fa-play fa-w-14" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" aria-hidden="true"><path fill="currentColor" d="M424.4 214.7L72.4 6.6C43.8-10.3 0 6.1 0 47.9V464c0 37.5 40.7 60.1 72.4 41.3l352-208c31.4-18.5 31.5-64.1 0-82.6z"></path></svg>', showBackgroundShape: false, linkHasLink: false, linkNewTab: false, linkHasTitle: true, blockBackgroundCustomSizeUnit: '%', blockBackgroundCustomSizeUnitTablet: '%', blockBackgroundCustomSizeUnitMobile: '%', iconColor1: '#FFFFFF',
+		}, innerBlocks: [],
+	}, {
+		name: 'stackable/image', attributes: {
+			uniqueId: 'd4394aa', hasBackground: false, hasBorders: false, imageShow: true, imageUrl: 'https://source.unsplash.com/800x500/?sea,coast,water', imageSize: 'full', imageShapeStretch: true, effectAnimationOut: {}, effectAnimationIn: {}, customAttributes: [], hideDesktop: false, hideTablet: false, hideMobile: false, displayCondition: {}, blockLinkHasLink: true, blockLinkNewTab: false, blockLinkHasTitle: true, blockBackgroundCustomSizeUnit: '%', blockBackgroundCustomSizeUnitTablet: '%', blockBackgroundCustomSizeUnitMobile: '%', imageWidthUnit: '%', imageWidthUnitTablet: '%', imageWidthUnitMobile: '%',
+		}, innerBlocks: [],
+	} ],
+}

--- a/src/block/video-popup-button/frontend-video-popup-button.js
+++ b/src/block/video-popup-button/frontend-video-popup-button.js
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import BigPicture from 'bigpicture'
+
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready'
+
+const getVideoProviderFromURL = url => {
+	let id = ''
+
+	// Check for YouTube.
+	id = ( url.match( /youtube\.com\/watch\?v=([^\&\?\/]+)/i ) || [] )[ 1 ]
+
+	if ( ! id ) {
+		id = ( url.match( /youtube\.com\/embed\/([^\&\?\/]+)/i ) || [] )[ 1 ]
+	}
+	if ( ! id ) {
+		id = ( url.match( /youtube\.com\/v\/([^\&\?\/]+)/i ) || [] )[ 1 ]
+	}
+	if ( ! id ) {
+		id = ( url.match( /youtu\.be\/([^\&\?\/]+)/i ) || [] )[ 1 ]
+	}
+
+	if ( id ) {
+		return {
+			type: 'youtube',
+			id,
+		}
+	}
+
+	// Check for Vimeo.
+	id = ( url.match( /vimeo\.com\/(\w*\/)*(\d+)/i ) || [] )[ 2 ]
+	if ( ! id ) {
+		id = ( url.match( /^\d+$/i ) || [] )[ 0 ]
+	}
+
+	if ( id ) {
+		return {
+			type: 'vimeo',
+			id,
+		}
+	}
+
+	return {
+		type: '',
+		id: url,
+	}
+}
+
+class StackableVideoPopupButton {
+	init = () => {
+		const els = document.querySelectorAll( '.stk-block-video-popup-button' )
+
+		const openVideo = el => {
+			if ( BigPicture ) {
+				const args = {
+					el,
+					noLoader: true,
+				}
+
+				const videoID = el.getAttribute( 'data-video' )
+				if ( videoID.match( /^https?:/ ) ) {
+					const { type, id } = getVideoProviderFromURL( videoID )
+					if ( type === 'youtube' ) {
+						args.ytSrc = id
+						args.ytNoCookie = true // Use youtube-nocookie.
+					} else if ( type === 'vimeo' ) {
+						args.vimeoSrc = id
+					} else {
+						args.vidSrc = id
+					}
+				}
+
+				BigPicture( args )
+			}
+		}
+		els.forEach( el => {
+			el.querySelector( '.wp-block-button' ).addEventListener( 'click', ev => {
+				ev.preventDefault()
+				openVideo( el )
+			} )
+		} )
+	}
+}
+
+window.stackableVideoPopupButton = new StackableVideoPopupButton()
+domReady( window.stackableVideoPopupButton.init )

--- a/src/block/video-popup-button/index.js
+++ b/src/block/video-popup-button/index.js
@@ -1,0 +1,31 @@
+/**
+ * BLOCK: Icon Label Block
+ */
+/**
+ * External dependencies
+ */
+import { VideoPopupIcon } from '~stackable/icons'
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit'
+import save from './save'
+import schema from './schema'
+import metadata from './block.json'
+import example from './example'
+
+export const settings = {
+	...metadata,
+	icon: VideoPopupIcon,
+	attributes: schema,
+	supports: {
+		anchor: true,
+		align: true,
+		stkAlign: true,
+	},
+	example,
+
+	edit,
+	save,
+}

--- a/src/block/video-popup-button/index.php
+++ b/src/block/video-popup-button/index.php
@@ -1,0 +1,21 @@
+<?php
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'stackable_load_videopopupbutton_frontend_script' ) ) {
+	function stackable_load_videopopupbutton_frontend_script() {
+		if ( ! is_admin() ) {
+			wp_enqueue_script(
+				'stk-frontend-video-popup-button',
+				plugins_url( 'dist/frontend_block_video_popup_button.js', STACKABLE_FILE ),
+				array(),
+				STACKABLE_VERSION,
+				true
+			);
+		}
+	}
+	add_action( 'stackable/video-popup-button/enqueue_scripts', 'stackable_load_videopopupbutton_frontend_script' );
+}

--- a/src/block/video-popup-button/save.js
+++ b/src/block/video-popup-button/save.js
@@ -1,0 +1,68 @@
+/**
+ * Internal dependencies
+ */
+import { IconLabelStyles } from './style'
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames'
+import { withVersion } from '~stackable/higher-order'
+import { i18n, version as VERSION } from 'stackable'
+import {
+	BlockDiv,
+	CustomCSS,
+	getAlignmentClasses,
+	getResponsiveClasses,
+	getRowClasses,
+} from '~stackable/block-components'
+
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor'
+import { compose } from '@wordpress/compose'
+import { __ } from '@wordpress/i18n'
+
+export const Save = props => {
+	const {
+		attributes, className,
+	} = props
+
+	const rowClass = getRowClasses( attributes )
+	const blockAlignmentClass = getAlignmentClasses( attributes )
+	const responsiveClass = getResponsiveClasses( attributes )
+
+	const blockClassNames = classnames( [
+		className,
+		'stk-block-video-popup-button',
+		responsiveClass,
+	] )
+
+	const contentClassNames = classnames( [
+		'stk-block-video-popup-button__overlay',
+		rowClass,
+		'stk-inner-blocks',
+		blockAlignmentClass,
+		'stk-block-content',
+		'stk-hover-parent',
+	] )
+
+	return (
+		<BlockDiv.Content
+			className={ blockClassNames }
+			attributes={ attributes }
+			data-video={ attributes.videoLink }
+		>
+			<IconLabelStyles.Content version={ props.version } attributes={ attributes } />
+			<CustomCSS.Content attributes={ attributes } />
+			<div className={ contentClassNames } aria-label={ attributes.ariaLabel || __( 'Play Video', i18n ) }>
+				<InnerBlocks.Content />
+			</div>
+		</BlockDiv.Content>
+	)
+}
+
+export default compose(
+	withVersion( VERSION )
+)( Save )

--- a/src/block/video-popup-button/schema.js
+++ b/src/block/video-popup-button/schema.js
@@ -1,0 +1,61 @@
+import {
+	Advanced,
+	Alignment,
+	BlockDiv,
+	Style,
+	ConditionalDisplay,
+	CustomAttributes,
+	CustomCSS,
+	EffectsAnimations,
+	MarginBottom,
+	Responsive,
+	Row,
+	Transform,
+} from '~stackable/block-components'
+import { AttributeObject } from '~stackable/util'
+import { version as VERSION } from 'stackable'
+
+export const attributes = ( version = VERSION ) => {
+	const attrObject = new AttributeObject()
+
+	BlockDiv.addAttributes( attrObject )
+	Style.addAttributes( attrObject )
+	MarginBottom.addAttributes( attrObject )
+	Row.addAttributes( attrObject )
+	Advanced.addAttributes( attrObject )
+	Transform.addAttributes( attrObject )
+	Alignment.addAttributes( attrObject )
+	EffectsAnimations.addAttributes( attrObject )
+	CustomAttributes.addAttributes( attrObject )
+	CustomCSS.addAttributes( attrObject )
+	Responsive.addAttributes( attrObject )
+	ConditionalDisplay.addAttributes( attrObject )
+	attrObject.add( {
+		attributes: {
+			videoLink: {
+				type: 'string',
+				default: '',
+			},
+			videoId: {
+				type: 'string',
+				source: 'attribute',
+				selector: '[data-video]',
+				attribute: 'data-video',
+				default: '',
+			},
+			ariaLabel: {
+				type: 'string',
+				source: 'attribute',
+				selector: 'button',
+				attribute: 'aria-label',
+				default: '',
+			},
+		},
+		versionAdded: '3.0.0',
+		versionDeprecated: '',
+	} )
+
+	return attrObject.getMerged( version )
+}
+
+export default attributes( VERSION )

--- a/src/block/video-popup-button/style.js
+++ b/src/block/video-popup-button/style.js
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import {
+	Advanced,
+	Alignment,
+	BlockDiv,
+	Column,
+	EffectsAnimations,
+	Transform,
+} from '~stackable/block-components'
+import { Style as StyleComponent } from '~stackable/components'
+import {
+	getUniqueBlockClass, useStyles, getStyles,
+} from '~stackable/util'
+
+/**
+ * WordPress dependencies
+ */
+import { memo, renderToString } from '@wordpress/element'
+
+const getStyleParams = () => {
+	return [
+		{
+			selector: '.stk-block-icon',
+			attrName: 'iconGap',
+			styleRule: 'flexBasis',
+			format: '%spx',
+		},
+	]
+}
+
+export const IconLabelStyles = memo( props => {
+	const styles = useStyles( getStyleParams() )
+
+	return (
+		<>
+			<Alignment.Style { ...props } />
+			<BlockDiv.Style { ...props } />
+			<Column.Style { ...props } />
+			<Advanced.Style { ...props } />
+			<Transform.Style { ...props } />
+			<EffectsAnimations.Style { ...props } />
+			<StyleComponent
+				styles={ styles }
+				versionAdded="3.0.0"
+				versionDeprecated=""
+				{ ...props }
+			/>
+		</>
+	)
+} )
+
+IconLabelStyles.defaultProps = {
+	isEditor: false,
+}
+
+IconLabelStyles.Content = props => {
+	const {
+		...propsToPass
+	} = props
+
+	if ( props.attributes.generatedCss ) {
+		return <style>{ props.attributes.generatedCss }</style>
+	}
+
+	propsToPass.blockUniqueClassName = getUniqueBlockClass( props.attributes.uniqueId )
+	const styles = getStyles( propsToPass.attributes, getStyleParams() )
+
+	const stylesToRender = (
+		<>
+			<Alignment.Style.Content { ...propsToPass } />
+			<BlockDiv.Style.Content { ...propsToPass } />
+			<Column.Style.Content { ...propsToPass } />
+			<EffectsAnimations.Style.Content { ...propsToPass } />
+			<Advanced.Style.Content { ...propsToPass } />
+			<Transform.Style.Content { ...propsToPass } />
+			<StyleComponent.Content
+				styles={ styles }
+				versionAdded="3.0.0"
+				versionDeprecated=""
+				{ ...propsToPass }
+			/>
+		</>
+	)
+
+	return renderToString( stylesToRender ) ? <style>{ stylesToRender }</style> : null
+}
+
+IconLabelStyles.Content.defaultProps = {
+	attributes: {},
+}

--- a/src/block/video-popup-button/style.scss
+++ b/src/block/video-popup-button/style.scss
@@ -1,0 +1,31 @@
+.stk-block-video-popup-button {
+	.stk-inner-blocks {
+		display: grid;
+		max-width: none !important;
+		.stk-block {
+			grid-column: 1 / 2;
+			grid-row: 1 / 2;
+			margin: 0;
+		}
+	}
+	.stk-block-icon {
+		justify-self: center;
+		align-self: center;
+		width: auto;
+		z-index: 2;
+	}
+	.stk-img-wrapper {
+		height: 100%;
+	}
+	:is(.stk-block-icon, .stk-block-image) {
+		--stk-block-margin-bottom: 0;
+	}
+}
+.stk-block-video-popup-button__overlay {
+	all: unset;
+	cursor: pointer;
+	margin: 0 auto;
+	display: grid;
+	width: 100% !important;
+	background-color: transparent !important;
+}

--- a/src/blocks.php
+++ b/src/blocks.php
@@ -92,6 +92,7 @@ if ( ! function_exists( 'stackable_get_stk_wrapper_block_folders_metadata' ) ) {
 			'icon-box',
 			'icon-label',
 			'image-box',
+			'image-popup',
 			'notification',
 			'posts',
 			'price',

--- a/src/blocks.php
+++ b/src/blocks.php
@@ -99,6 +99,7 @@ if ( ! function_exists( 'stackable_get_stk_wrapper_block_folders_metadata' ) ) {
 			'team-member',
 			'testimonial',
 			'video-popup',
+			'video-popup-button',
 		);
 
 		return stackable_get_metadata_by_folders( $stk_wrapper_block_folders, 'stk-wrapper-block-folders' );

--- a/src/plugins/design-library-button/design-library-button.js
+++ b/src/plugins/design-library-button/design-library-button.js
@@ -34,7 +34,6 @@ const DesignLibraryButton = () => {
 		<Button
 			onClick={ onClick }
 			className="ugb-insert-library-button"
-			label={ __( 'Open Design Library', i18n ) }
 			icon={ <SVGStackableIcon /> }
 		>{ __( 'Design Library', i18n ) }</Button>
 	)


### PR DESCRIPTION
I had a client request for an image popup for posts where they don't yet have video (and we're already using the Stackable video popup). So this just provide a new, separate block. In retrospect it might be better to just enhance the existing video popup block to permit setting images.