### PR TITLE
fix (heading): heading tag default reset

### DIFF
--- a/src/components/heading-buttons-control/index.js
+++ b/src/components/heading-buttons-control/index.js
@@ -69,7 +69,8 @@ const HeadingButtonsControl = memo( props => {
 			{ ...props }
 			className="ugb-heading-buttons-control"
 			controls={ props.hasP ? TAG_OPTIONS : TAG_OPTIONS_NOP }
-			placeholder={ TAG_OPTIONS[ 0 ].value }
+			placeholder={ TAG_OPTIONS[ 1 ].value }
+			default={ TAG_OPTIONS[ 1 ].value }
 		/>
 	)
 } )


### PR DESCRIPTION
Fixes:
* HTML Tag reset button showing on default value
* Reverting to H1 instead of H2