### PR TITLE
fix: filter on the block unique classname for saving styles

### DIFF
--- a/src/components/block-css/index.js
+++ b/src/components/block-css/index.js
@@ -347,6 +347,8 @@ const BlockCss = props => {
 
 	if ( ! props.editorMode ) {
 		blockUniqueClassName = applyFilters( 'stackable.block-css.uniqueClass.save', blockUniqueClassName, attributes )
+	} else {
+		blockUniqueClassName = applyFilters( 'stackable.block-css.uniqueClass.edit', blockUniqueClassName )
 	}
 
 	// Selectors can be arrays, flatten them.

--- a/src/components/block-css/index.js
+++ b/src/components/block-css/index.js
@@ -345,6 +345,10 @@ const BlockCss = props => {
 		collapsedSelector = collapsedSelector.replace( /[^^?](.%s)([^-])/g, `$1-${ instanceId }$2` )
 	}
 
+	if ( ! props.editorMode ) {
+		blockUniqueClassName = applyFilters( 'stackable.block-css.uniqueClass.save', blockUniqueClassName, attributes )
+	}
+
 	// Selectors can be arrays, flatten them.
 	if ( Array.isArray( selector ) ) {
 		selector = selector.join( ', ' )
@@ -410,6 +414,7 @@ const BlockCss = props => {
 	// the save function, the edit does the filter in the BlockCssEdit
 	// component.
 	if ( ! props.editorMode ) {
+		// Note that the original css value is always empty, see addCssToCssSaveObject.
 		css = applyFilters( 'stackable.block-styles.save', css, blockUniqueClassName, attributes )
 	}
 


### PR DESCRIPTION
Add a way to match the modified block unique class on styles and on HTML nodes. Also, add a note on a filter since the original value will always be empty - please consider deprecating the filter altogether.

Ref: https://github.com/gambitph/Stackable/issues/2588