### PR TITLE
fix (advance-range-control): increased specificity to prevent native WP styling from overriding css. 

### DIFF
--- a/src/components/advanced-range-control/editor.scss
+++ b/src/components/advanced-range-control/editor.scss
@@ -39,7 +39,7 @@
 		margin-left: 8px;
 	}
 	.components-base-control__field,
-	.components-base-control {
+	.components-input-control.components-base-control {
 		margin-bottom: 0;
 	}
 


### PR DESCRIPTION
Fixes #2604 