### PR TITLE
feat: lightbox

### DIFF
--- a/.config/webpack.config.dev.js
+++ b/.config/webpack.config.dev.js
@@ -166,6 +166,7 @@ module.exports = [
 	target: [ 'web', 'es2017' ],
 
 	entry: {
+		'frontend_image_lightbox': path.resolve( __dirname, '../src/lightbox/frontend-image-lightbox.js' ),
 		'frontend_blocks': path.resolve( __dirname, '../src/block-frontend.js' ),
 		'frontend_block_accordion': path.resolve( __dirname, '../src/block/accordion/frontend-accordion.js' ),
 		'frontend_block_accordion_polyfill': path.resolve( __dirname, '../src/block/accordion/frontend-accordion-polyfill.js' ),

--- a/.config/webpack.config.prod.js
+++ b/.config/webpack.config.prod.js
@@ -151,6 +151,7 @@ module.exports = [
 	target: [ 'web', 'es2017' ],
 
 	entry: {
+		'frontend_image_lightbox': path.resolve( __dirname, '../src/lightbox/frontend-image-lightbox.js' ),
 		'frontend_blocks': path.resolve( __dirname, '../src/block-frontend.js' ),
 		'frontend_block_accordion': path.resolve( __dirname, '../src/block/accordion/frontend-accordion.js' ),
 		'frontend_block_accordion_polyfill': path.resolve( __dirname, '../src/block/accordion/frontend-accordion-polyfill.js' ),

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,6 +47,7 @@ const sassOptions = {
 	includePaths: [
 		path.resolve( __dirname, './src/' ),
 		path.resolve( __dirname, './src/styles' ),
+		'./node_modules',
 	],
 }
 
@@ -266,6 +267,17 @@ gulp.task( 'style', gulp.series(
 			// which are added to force correct sorting of media queries by
 			// mqpacker
 			.pipe( replace( /.z\s?{\s?opacity:\s?1;?}/g, '' ) )
+			.pipe( gulp.dest( 'dist/' ) )
+	},
+	// Build the lightbox specific styles.
+	function styleImageLightboxCSS() {
+		return gulp.src( [ path.resolve( __dirname, './src/lightbox/frontend-image-lightbox.scss' ) ] )
+			.pipe( sass( sassOptions ).on( 'error', sass.logError ) )
+			.pipe( postcss( postCSSOptions ) )
+			.pipe( rename( {
+				basename: 'frontend_image_lightbox',
+				dirname: '',
+			} ) )
 			.pipe( gulp.dest( 'dist/' ) )
 	},
 	function generateResponsiveCSS() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"counterup2": "^2.0.2",
 				"deepmerge": "^3.3.0",
 				"fast-deep-equal": "^3.1.3",
+				"glightbox": "^3.2.0",
 				"is-dark-color": "^1.2.0",
 				"md5": "^2.3.0",
 				"prop-types": "^15.7.2",
@@ -14311,6 +14312,11 @@
 				"encoding": "^0.1.12",
 				"safe-buffer": "^5.1.1"
 			}
+		},
+		"node_modules/glightbox": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/glightbox/-/glightbox-3.2.0.tgz",
+			"integrity": "sha512-iit1xYixqL4YVL+I2YJLfMeyJwvLi6FE6kY3qNKeZHEJgRIz80QU8Rm7YCyw1wOTgXvmNDnXGVhHOHRCwnDltQ=="
 		},
 		"node_modules/glob": {
 			"version": "7.2.0",
@@ -43441,6 +43447,11 @@
 				"encoding": "^0.1.12",
 				"safe-buffer": "^5.1.1"
 			}
+		},
+		"glightbox": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/glightbox/-/glightbox-3.2.0.tgz",
+			"integrity": "sha512-iit1xYixqL4YVL+I2YJLfMeyJwvLi6FE6kY3qNKeZHEJgRIz80QU8Rm7YCyw1wOTgXvmNDnXGVhHOHRCwnDltQ=="
 		},
 		"glob": {
 			"version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"counterup2": "^2.0.2",
 		"deepmerge": "^3.3.0",
 		"fast-deep-equal": "^3.1.3",
+		"glightbox": "^3.2.0",
 		"is-dark-color": "^1.2.0",
 		"md5": "^2.3.0",
 		"prop-types": "^15.7.2",

--- a/plugin.php
+++ b/plugin.php
@@ -192,6 +192,7 @@ require_once( plugin_dir_path( __FILE__ ) . 'src/design-library/init.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/global-settings.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/custom-block-styles.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/css-optimize.php' );
+require_once( plugin_dir_path( __FILE__ ) . 'src/lightbox/index.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/block/accordion/index.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/block/count-up/index.php' );
 require_once( plugin_dir_path( __FILE__ ) . 'src/block/countdown/index.php' );

--- a/src/block-components/block-div/index.js
+++ b/src/block-components/block-div/index.js
@@ -128,6 +128,8 @@ BlockDiv.Content = props => {
 				// effect in the frontend. This is okay in the editor-side.
 				'stk--block-margin-top-auto': attributes.blockMargin?.top === 'auto',
 				'stk--block-margin-bottom-auto': attributes.blockMargin?.bottom === 'auto',
+				// Advanced > Link > Has Lightbox support.
+				'stk--has-lightbox': attributes.blockLinkHasLightbox || attributes.linkHasLightbox,
 			},
 		],
 		props

--- a/src/block-components/block-link/edit.js
+++ b/src/block-components/block-link/edit.js
@@ -13,7 +13,13 @@ import {
 import { __ } from '@wordpress/i18n'
 import { LinkControls } from '../helpers/link'
 
-export const Edit = ( { hasLink, hasTitle } ) => {
+export const Edit = props => {
+	const {
+		hasLink,
+		hasTitle,
+		hasLightbox,
+	} = props
+
 	return (
 		<>
 			<InspectorAdvancedControls>
@@ -21,7 +27,13 @@ export const Edit = ( { hasLink, hasTitle } ) => {
 					title={ __( 'Link', i18n ) }
 					id="link"
 				>
-					<LinkControls attrNameTemplate="blockLink%s" hasLink={ hasLink } hasTitle={ hasTitle } />
+					<LinkControls
+						attrNameTemplate="blockLink%s"
+						hasLink={ hasLink }
+						hasTitle={ hasTitle }
+						hasLightbox={ hasLightbox }
+						lightboxHelp={ __( 'Supports links to images, videos, YouTube, Vimeo, and web pages that allow embedding. Opens inner image block if no link is provided', i18n ) }
+					/>
 				</PanelAdvancedSettings>
 			</InspectorAdvancedControls>
 		</>
@@ -31,4 +43,5 @@ export const Edit = ( { hasLink, hasTitle } ) => {
 Edit.defaultProps = {
 	hasLink: true,
 	hasTitle: true,
+	hasLightbox: true,
 }

--- a/src/block-components/helpers/link/attributes.js
+++ b/src/block-components/helpers/link/attributes.js
@@ -36,6 +36,10 @@ export const linkAttributes = ( selector = 'a' ) => {
 			attribute: 'title',
 			default: '',
 		},
+		hasLightbox: {
+			type: 'boolean',
+			default: false,
+		},
 	}
 }
 

--- a/src/block-components/helpers/link/edit.js
+++ b/src/block-components/helpers/link/edit.js
@@ -16,6 +16,8 @@ export const LinkControls = props => {
 	const {
 		hasLink,
 		hasTitle,
+		hasLightbox,
+		lightboxHelp,
 	} = props
 
 	const {
@@ -37,6 +39,14 @@ export const LinkControls = props => {
 				checked={ getAttribute( 'newTab' ) }
 				onChange={ updateAttributeHandler( 'newTab' ) }
 			/>
+			{ hasLightbox &&
+				<AdvancedToggleControl
+					label={ __( 'Open Link in Lightbox', i18n ) }
+					help={ lightboxHelp }
+					checked={ getAttribute( 'hasLightbox' ) }
+					onChange={ updateAttributeHandler( 'hasLightbox' ) }
+				/>
+			}
 			<AdvancedTextControl
 				label={ __( 'Link rel', i18n ) }
 				value={ getAttribute( 'rel' ) }
@@ -59,4 +69,6 @@ LinkControls.defaultProps = {
 	attrNameTemplate: '%s',
 	hasLink: true,
 	hasTitle: false,
+	hasLightbox: false,
+	lightboxHelp: __( 'Supports links to images, videos, YouTube, Vimeo, and web pages that allow embedding', i18n ),
 }

--- a/src/block-components/image/attributes.js
+++ b/src/block-components/image/attributes.js
@@ -108,6 +108,10 @@ export const addAttributes = ( attrObject, options = {} ) => {
 				type: 'number',
 				default: '',
 			},
+			imageHasLightbox: {
+				type: 'boolean',
+				default: false,
+			},
 			imageZoom: {
 				stkHover: true,
 				type: 'number',

--- a/src/block-components/image/edit.js
+++ b/src/block-components/image/edit.js
@@ -63,6 +63,7 @@ const Controls = props => {
 			imageHeightUnit: attributes.imageHeightUnit,
 			imageWidth: attributes.imageWidth,
 			imageHeight: attributes.imageHeight,
+			imageHasLightbox: attributes.imageHasLightbox,
 			imageSize: attributes.imageSize,
 			imageAlt: attributes.imageAlt,
 			imageOverlayColorType: attributes.imageOverlayColorType,
@@ -168,6 +169,13 @@ const Controls = props => {
 					allowReset={ true }
 					placeholder=""
 					responsive="all"
+				/>
+			}
+
+			{ props.hasLightbox &&
+				<AdvancedToggleControl
+					label={ __( 'Open Image in Lightbox', i18n ) }
+					attribute="imageHasLightbox"
 				/>
 			}
 

--- a/src/block-components/image/image.js
+++ b/src/block-components/image/image.js
@@ -49,6 +49,8 @@ const getImageWrapperClasses = props => {
 		[ `stk--shadow-${ props.shadow }` ]: ! props.shape && props.shadow,
 
 		'stk-img--gradient-overlay': props.hasGradientOverlay,
+
+		'stk--has-lightbox': props.hasLightbox,
 	} )
 }
 

--- a/src/block-components/image/index.js
+++ b/src/block-components/image/index.js
@@ -57,6 +57,7 @@ export const Image = props => {
 			imageHeightUnit: attributes.imageHeightUnit,
 			imageHeightUnitTablet: attributes.imageHeightUnitTablet,
 			imageHeightUnitMobile: attributes.imageHeightUnitMobile,
+			imageHasLightbox: attributes.imageHasLightbox,
 			imageShape: attributes.imageShape,
 			imageShapeStretch: attributes.imageShapeStretch,
 			imageShadow: attributes.imageShadow,
@@ -106,6 +107,7 @@ export const Image = props => {
 		shadow={ attributes.imageShadow }
 
 		hasGradientOverlay={ hasHoverOverlay }
+		hasLightbox={ attributes.imageHasLightbox }
 
 		defaultWidth={ props.defaultWidth }
 		defaultHeight={ props.defaultHeight }
@@ -157,6 +159,7 @@ Image.Content = props => {
 		shadow={ attributes.imageShadow }
 
 		hasGradientOverlay={ hasHoverOverlay }
+		hasLightbox={ attributes.imageHasLightbox }
 
 		{ ...propsToPass }
 	/>

--- a/src/block-components/link/edit.js
+++ b/src/block-components/link/edit.js
@@ -39,7 +39,7 @@ export const Edit = props => {
 				checked={ props.hasToggle ? hasLink : undefined }
 				onChange={ props.hasToggle ? onChange : undefined }
 			>
-				<LinkControls attrNameTemplate="link%s" />
+				<LinkControls attrNameTemplate="link%s" hasLightbox />
 			</PanelAdvancedSettings>
 		</Tab>
 	)

--- a/src/block/image/edit.js
+++ b/src/block/image/edit.js
@@ -74,6 +74,7 @@ const Edit = props => {
 						{ ...props }
 						initialOpen={ true }
 						heightUnits={ heightUnit }
+						hasLightbox
 					/>
 					{ enableLink && <Link.InspectorControls hasTitle={ true } isAdvancedTab={ true } /> }
 					<BlockDiv.InspectorControls />

--- a/src/init.php
+++ b/src/init.php
@@ -220,6 +220,12 @@ if ( ! class_exists( 'Stackable_Init' ) ) {
 				$this->scripts_loaded[] = $stackable_block;
 			}
 
+			// Check whether the current block needs to enqueue some scripts.
+			// This gets called across all the blocks.
+			if ( stripos( $block_name, 'stackable/' ) === 0 ) {
+				do_action( 'stackable/enqueue_scripts', $block_content, $block );
+			}
+
 			return $block_content;
 		}
 

--- a/src/lightbox/frontend-image-lightbox.js
+++ b/src/lightbox/frontend-image-lightbox.js
@@ -26,7 +26,7 @@ const detectIfVideo = url => {
 }
 
 const isButtonBlock = el => {
-	return el.classList.contains( 'stk-block-button' ) || el.classList.contains( 'stk-block-icon' )
+	return el.classList.contains( 'stk-block-button' ) || el.classList.contains( 'stk-block-icon-button' ) || el.classList.contains( 'stk-block-icon' )
 }
 
 class StackableImageLightbox {
@@ -43,7 +43,7 @@ class StackableImageLightbox {
 			// Look for the anchor link where we can get the link to open in the
 			// lightbox.
 			let link = el.querySelector( '.stk-link:not(.stk-button)' )
-			if ( el.classList.contains( 'stk-block-button' ) ) {
+			if ( isButtonBlock( el ) ) {
 				link = el.querySelector( '.stk-link' )
 			}
 			if ( imageBlock && ! link ) {

--- a/src/lightbox/frontend-image-lightbox.js
+++ b/src/lightbox/frontend-image-lightbox.js
@@ -1,0 +1,72 @@
+import domReady from '@wordpress/dom-ready'
+import GLightbox from 'glightbox'
+
+const getImageFromSrcset = el => {
+	const src = el.getAttribute( 'srcset' ).split( ',' ).map( v => v.trim().split( ' ' ) ).reduce( ( largestImgData, imgData ) => {
+		const size = parseInt( imgData[ 1 ], 10 )
+		if ( largestImgData.size < size ) {
+			return { url: imgData[ 0 ], size }
+		}
+		return largestImgData
+	}, { url: '', size: 0 } )
+	return src.url
+}
+
+class StackableImageLightbox {
+	init = () => {
+		this.elements = []
+
+		document.querySelectorAll( '.stk--has-lightbox' ).forEach( el => {
+			const imageBlock = el.querySelector( 'img[srcset]' )
+
+			// Look for the anchor link where we can get the link to open in the
+			// lightbox.
+			let link = el.querySelector( '.stk-link:not(.stk-button)' )
+			if ( el.classList.contains( 'stk-block-button' ) ) {
+				link = el.querySelector( '.stk-link' )
+			}
+			if ( imageBlock && ! link ) {
+				link = imageBlock.closest( '.stk-link' ) || imageBlock.closest( 'a' )
+			}
+
+			const href = link && link.getAttribute( 'href' )
+
+			// The link to open either comes from the href, or from the srcset
+			// of an image block.
+			const linkToOpen = link && href ? href
+				: imageBlock ? getImageFromSrcset( imageBlock )
+					: null
+
+			if ( ! linkToOpen ) {
+				return
+			}
+
+			if ( ! link ) {
+				link = el
+			}
+
+			const isUsingImageBlock = ( ! link || ! href ) && imageBlock
+
+			const lightbox = GLightbox( {
+				elements: [ link ],
+				href: linkToOpen,
+				// If we're using an image block as the source, the link to open
+				// isn't sometimes detected as an image.
+				type: isUsingImageBlock ? 'image' : undefined,
+			} )
+
+			link.style.cursor = 'pointer'
+			link.setAttribute( 'aria-role', 'button' )
+
+			link.addEventListener( 'click', ev => {
+				lightbox.open()
+				ev.preventDefault()
+				ev.stopImmediatePropagation()
+			} )
+		} )
+	}
+}
+
+window.stackableImageLightbox = new StackableImageLightbox()
+domReady( window.stackableImageLightbox.init )
+

--- a/src/lightbox/frontend-image-lightbox.js
+++ b/src/lightbox/frontend-image-lightbox.js
@@ -1,6 +1,7 @@
 import domReady from '@wordpress/dom-ready'
 import GLightbox from 'glightbox'
 
+// Gets the highest resolution image from the srcset.
 const getImageFromSrcset = el => {
 	const src = el.getAttribute( 'srcset' ).split( ',' ).map( v => v.trim().split( ' ' ) ).reduce( ( largestImgData, imgData ) => {
 		const size = parseInt( imgData[ 1 ], 10 )
@@ -12,10 +13,30 @@ const getImageFromSrcset = el => {
 	return src.url
 }
 
+// Detects the type of the URL if it's a video URL.
+const detectIfVideo = url => {
+	if ( url.match( /(youtube\.com|youtu\.be)/ ) ) {
+		return true
+	} else if ( url.match( /vimeo\.com/ ) ) {
+		return true
+	} else if ( url.match( /\.(mp4|webm|mov)$/i ) ) {
+		return true
+	}
+	return false
+}
+
+const isButtonBlock = el => {
+	return el.classList.contains( 'stk-block-button' ) || el.classList.contains( 'stk-block-icon' )
+}
+
 class StackableImageLightbox {
 	init = () => {
 		this.elements = []
+		this.gatherImages()
+		this.createLightboxes()
+	}
 
+	gatherImages = () => {
 		document.querySelectorAll( '.stk--has-lightbox' ).forEach( el => {
 			const imageBlock = el.querySelector( 'img[srcset]' )
 
@@ -47,22 +68,93 @@ class StackableImageLightbox {
 
 			const isUsingImageBlock = ( ! link || ! href ) && imageBlock
 
-			const lightbox = GLightbox( {
-				elements: [ link ],
+			this.elements.push( {
+				block: link.classList.contains( 'stk-block' ) ? link : link.closest( '.stk-block' ),
+				element: link,
 				href: linkToOpen,
 				// If we're using an image block as the source, the link to open
 				// isn't sometimes detected as an image.
 				type: isUsingImageBlock ? 'image' : undefined,
 			} )
+		} )
+	}
 
-			link.style.cursor = 'pointer'
-			link.setAttribute( 'aria-role', 'button' )
+	createLightboxes = () => {
+		// Group together elements that belong to blocks which are adjacent to one another.
+		const elementsGrouped = this.elements.reduce( ( elements, element, index ) => {
+			const nextElementBlock = index + 1 < this.elements.length ? this.elements[ index + 1 ].block : undefined
+			const prevElementBlock = index > 0 ? this.elements[ index - 1 ].block : undefined
+			const { block } = element
+			let isNextBlockAdjacent = block.nextElementSibling === nextElementBlock
+			let isPrevBlockAdjacent = block.previousElementSibling === prevElementBlock
 
-			link.addEventListener( 'click', ev => {
-				lightbox.open()
-				ev.preventDefault()
-				ev.stopImmediatePropagation()
-			} )
+			// Button blocks are always not grouped together.
+			if ( isNextBlockAdjacent && isButtonBlock( nextElementBlock ) ) {
+				isNextBlockAdjacent = false
+			}
+			if ( isPrevBlockAdjacent && isButtonBlock( prevElementBlock ) ) {
+				isPrevBlockAdjacent = false
+			}
+			if ( isButtonBlock( block ) ) {
+				isNextBlockAdjacent = false
+				isPrevBlockAdjacent = false
+			}
+
+			if ( ! isPrevBlockAdjacent && isNextBlockAdjacent ) {
+				elements.push( [ element ] )
+			} else if ( isPrevBlockAdjacent ) {
+				elements[ elements.length - 1 ].push( element )
+			} else {
+				elements.push( element )
+			}
+
+			return elements
+		}, [] )
+
+		elementsGrouped.forEach( elementGroup => {
+			// If the blocks are beside each other, display as a gallery.
+			if ( Array.isArray( elementGroup ) ) {
+				const elements = elementGroup.map( ( {
+					element, href, type,
+				} ) => {
+					return {
+						elements: [ element ],
+						href,
+						// We'll need to detect the type because auto-detect
+						// doesn't work here for some unknown reason.
+						type: type || ( detectIfVideo( href ) ? 'video' : 'image' ),
+					}
+				} )
+
+				const lightbox = GLightbox( { elements } )
+
+				elementGroup.forEach( ( { element }, i ) => {
+					this.addClickHandler( element, lightbox, i )
+				} )
+			} else {
+				const {
+					element, href, type,
+				} = elementGroup
+
+				const lightbox = GLightbox( {
+					elements: [ element ],
+					href,
+					type,
+				} )
+
+				this.addClickHandler( element, lightbox, 0 )
+			}
+		} )
+	}
+
+	addClickHandler = ( element, lightbox, i ) => {
+		element.style.cursor = 'pointer'
+		element.setAttribute( 'aria-role', 'button' )
+
+		element.addEventListener( 'click', ev => {
+			lightbox.openAt( i )
+			ev.preventDefault()
+			ev.stopImmediatePropagation()
 		} )
 	}
 }

--- a/src/lightbox/frontend-image-lightbox.scss
+++ b/src/lightbox/frontend-image-lightbox.scss
@@ -1,0 +1,1 @@
+@import "glightbox/dist/css/glightbox";

--- a/src/lightbox/index.php
+++ b/src/lightbox/index.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Loads the lightbox scripts and styles that will make the lightbox work in the
+ * frontend.
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'stackable_load_lightbox_frontend_script' ) ) {
+	function stackable_load_lightbox_frontend_script( $block_content, $block ) {
+		if ( ! is_admin() ) {
+			if ( array_key_exists( 'attrs', $block ) ) {
+				// If the block has one of these 3 attributes, then we'll need
+				// to load the lightbox script and styles.
+				if ( ( array_key_exists( 'imageHasLightbox', $block['attrs'] ) && $block['attrs']['imageHasLightbox'] ) ||
+				     ( array_key_exists( 'blockLinkHasLightbox', $block['attrs'] ) && $block['attrs']['blockLinkHasLightbox'] ) ||
+				     ( array_key_exists( 'linkHasLightbox', $block['attrs'] ) && $block['attrs']['linkHasLightbox'] ) ) {
+
+					wp_enqueue_script(
+						'stk-frontend-image-lightbox',
+						plugins_url( 'dist/frontend_image_lightbox.js', STACKABLE_FILE ),
+						array(),
+						STACKABLE_VERSION,
+						true
+					);
+					wp_enqueue_style(
+						'stk-frontend-image-lightbox',
+						plugins_url( 'dist/frontend_image_lightbox.css', STACKABLE_FILE ),
+						array(),
+						STACKABLE_VERSION
+					);
+				}
+			}
+		}
+	}
+	add_action( 'stackable/enqueue_scripts', 'stackable_load_lightbox_frontend_script', 10, 2 );
+}


### PR DESCRIPTION
**What’s New:**

- Image block: new Open Image in Lightbox option under Style tab > Image
- Button block & icon block: new Open Link in Lightbox under Style tab > Link
- Container blocks: new Open Link in Lightbox under Adv tab > Link

**Lightbox Capabilities:**

- Easy to use: if you have an Image Box block, you can just **check** the Open Link in Lightbox option under Adv tab > Link and the lightbox should work right away.
- Responsive: works great in mobile, you can swipe left/right in a gallery, swipe up to close it.
- For container-type blocks: if enabled (and no link is provided), can open the high resolution version of the image block inside it
- Can open these in a lightbox:
    - locally hosted images
    - locally hosted video files
    - YouTube urls
    - Vimeo urls
    - Other web pages (but only if the website allows embedding, e.g. [https://google.com/](https://google.com) doesn’t allow it)
- Adjacent blocks with lightbox enabled will display as a lightbox **gallery** (there's a left and right arrow that can be used to navigate)
    - The lightbox gallery only works for images and videos (not embedded web pages)
    - e.g. Add multiple image blocks one after another and enable lightbox on them.