### PR TITLE
Fix: The title and description of the blocks in "Getting Started" are not shown translated

### DIFF
--- a/src/welcome/admin.js
+++ b/src/welcome/admin.js
@@ -68,8 +68,8 @@ const BlockList = () => {
 										key={ i }
 										className="s-box"
 									>
-										<h4>{ block.title }</h4>
-										<p>{ block.description }</p>
+										<h4>{ __( block.title, i18n ) }</h4>
+										<p>{ __( block.description, i18n ) }</p>
 										{ block[ 'stk-demo' ] && <a href={ block[ 'stk-demo' ] } target="_example">{ __( 'See example', i18n ) }</a> }
 									</div>
 								)


### PR DESCRIPTION
Update admin.js

Probable fix #2597 