### PR TITLE
fix (admin-page): block linking learn more button in the admin page redirects to the correct link

### DIFF
--- a/src/welcome/admin.js
+++ b/src/welcome/admin.js
@@ -294,7 +294,7 @@ const EditorSettings = () => {
 				<>
 					{ __( 'Gives you the ability to link columns. Any changes you make on one column will automatically get applied on the other columns.', i18n ) }
 					&nbsp;
-					<a target="_docs" href="https://docs.wpstackable.com/article/462-migrating-from-version-2-to-version-3?utm_source=wp-settings-migrating&utm_campaign=learnmore&utm_medium=wp-dashboard">{ __( 'Learn more', i18n ) }</a>
+					<a target="_docs" href="https://docs.wpstackable.com/article/452-how-to-use-block-linking">{ __( 'Learn more', i18n ) }</a>
 				</>
 			}
 		/>


### PR DESCRIPTION
Fixes #2564 