### PR TITLE
Changed from `__` to `_x` for TOC example translatable strings for context argument

### DIFF
--- a/src/block/table-of-contents/example.js
+++ b/src/block/table-of-contents/example.js
@@ -6,10 +6,10 @@ import { i18n } from 'stackable'
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n'
+import { _x } from '@wordpress/i18n'
 
 export default {
 	attributes: {
-		example: `<li><a href="#0">${ __( 'Introduction', 'Table of Contents example text', i18n ) }<a/></li><li><a href="#0">${ __( 'Chapter 1: Abstract', 'Table of Contents example text', i18n ) }<a/></li><li><a href="#0">${ __( 'Chapter 2: History', 'Table of Contents example text', i18n ) }<a/></li><li><a href="#0">${ __( 'Chapter 3: Main Content', 'Table of Contents example text', i18n ) }<a/></li><li><a href="#0">${ __( 'Chapter 4: Additional Thoughts', 'Table of Contents example text', i18n ) }<a/></li><li><a href="#0">${ __( 'Conclusion', 'Table of Contents example text', i18n ) }<a/></li>`,
+		example: `<li><a href="#0">${ _x( 'Introduction', 'Table of Contents example text', i18n ) }<a/></li><li><a href="#0">${ _x( 'Chapter 1: Abstract', 'Table of Contents example text', i18n ) }<a/></li><li><a href="#0">${ _x( 'Chapter 2: History', 'Table of Contents example text', i18n ) }<a/></li><li><a href="#0">${ _x( 'Chapter 3: Main Content', 'Table of Contents example text', i18n ) }<a/></li><li><a href="#0">${ _x( 'Chapter 4: Additional Thoughts', 'Table of Contents example text', i18n ) }<a/></li><li><a href="#0">${ _x( 'Conclusion', 'Table of Contents example text', i18n ) }<a/></li>`,
 	}, innerBlocks: [],
 }

--- a/src/block/table-of-contents/index.js
+++ b/src/block/table-of-contents/index.js
@@ -18,7 +18,7 @@ import deprecated from './deprecated'
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n'
+import { _x } from '@wordpress/i18n'
 import { addFilter } from '@wordpress/hooks'
 
 export const settings = {
@@ -32,32 +32,32 @@ export const settings = {
 			[ 'stackable/table-of-contents', {} ],
 			// We need to add sample headings for the table of contents block to show things.
 			[ 'core/heading', {
-				content: __( 'Introduction', 'Table of Contents example text', i18n ),
+				content: _x( 'Introduction', 'Table of Contents example text', i18n ),
 				anchor: 'heading',
 				level: 2,
 			} ],
 			[ 'core/heading', {
-				content: __( 'Chapter 1: Abstract', 'Table of Contents example text', i18n ),
+				content: _x( 'Chapter 1: Abstract', 'Table of Contents example text', i18n ),
 				anchor: 'heading',
 				level: 2,
 			} ],
 			[ 'core/heading', {
-				content: __( 'Chapter 2: History', 'Table of Contents example text', i18n ),
+				content: _x( 'Chapter 2: History', 'Table of Contents example text', i18n ),
 				anchor: 'heading',
 				level: 2,
 			} ],
 			[ 'core/heading', {
-				content: __( 'Chapter 3: Main Content', 'Table of Contents example text', i18n ),
+				content: _x( 'Chapter 3: Main Content', 'Table of Contents example text', i18n ),
 				anchor: 'heading',
 				level: 2,
 			} ],
 			[ 'core/heading', {
-				content: __( 'Chapter 4: Additional Thoughts', 'Table of Contents example text', i18n ),
+				content: _x( 'Chapter 4: Additional Thoughts', 'Table of Contents example text', i18n ),
 				anchor: 'heading',
 				level: 2,
 			} ],
 			[ 'core/heading', {
-				content: __( 'Conclusion', 'Table of Contents example text', i18n ),
+				content: _x( 'Conclusion', 'Table of Contents example text', i18n ),
 				anchor: 'heading',
 				level: 2,
 			} ],


### PR DESCRIPTION
Changed from `__` to `_x` for TOC example translatable strings for context argument

![stk-toc](https://github.com/gambitph/Stackable/assets/1197819/95a86079-4f5f-4de9-9a78-9f9f494b466e)
