### PR TITLE
fix: addresses accessibility warning in expand/show more block and accordion block

### DIFF
--- a/src/block/expand/edit.js
+++ b/src/block/expand/edit.js
@@ -47,7 +47,7 @@ const TEMPLATE = [
 		text: __( 'Show more', i18n ),
 		linkUrl: '#',
 		className: 'is-style-link stk-block-expand__show-button',
-		customAttributes: [ [ 'aria-hidden', 'false' ], [ 'role', 'button' ] ],
+		customAttributes: [ [ 'aria-hidden', 'false' ], [ 'role', 'button' ], [ 'aria-expanded', 'true' ] ],
 	} ],
 	[ 'stackable/text', {
 		text: __( 'Some long text that will be expanded when the show more button is clicked by the visitor.', i18n ),
@@ -58,7 +58,7 @@ const TEMPLATE = [
 		text: __( 'Show less', i18n ),
 		linkUrl: '#',
 		className: 'is-style-link stk-block-expand__hide-button',
-		customAttributes: [ [ 'aria-hidden', 'true' ], [ 'role', 'button' ] ],
+		customAttributes: [ [ 'aria-hidden', 'true' ], [ 'role', 'button' ], [ 'aria-expanded', 'false' ] ],
 	} ],
 ]
 

--- a/src/block/expand/edit.js
+++ b/src/block/expand/edit.js
@@ -47,7 +47,7 @@ const TEMPLATE = [
 		text: __( 'Show more', i18n ),
 		linkUrl: '#',
 		className: 'is-style-link stk-block-expand__show-button',
-		customAttributes: [ [ 'aria-hidden', 'false' ], [ 'role', 'button' ], [ 'aria-expanded', 'true' ] ],
+		customAttributes: [ [ 'aria-hidden', 'false' ], [ 'role', 'button' ], [ 'aria-expanded', 'false' ] ],
 	} ],
 	[ 'stackable/text', {
 		text: __( 'Some long text that will be expanded when the show more button is clicked by the visitor.', i18n ),
@@ -58,7 +58,7 @@ const TEMPLATE = [
 		text: __( 'Show less', i18n ),
 		linkUrl: '#',
 		className: 'is-style-link stk-block-expand__hide-button',
-		customAttributes: [ [ 'aria-hidden', 'true' ], [ 'role', 'button' ], [ 'aria-expanded', 'false' ] ],
+		customAttributes: [ [ 'aria-hidden', 'true' ], [ 'role', 'button' ], [ 'aria-expanded', 'true' ] ],
 	} ],
 ]
 

--- a/src/block/expand/frontend-expand.js
+++ b/src/block/expand/frontend-expand.js
@@ -6,6 +6,8 @@ import domReady from '@wordpress/dom-ready'
 class StackableExpand {
 	init = () => {
 		const els = document.querySelectorAll( '.stk-block-expand .stk-button' )
+		const blocks = document.querySelectorAll( '.stk-block-expand' )
+
 		const onClick = event => {
 			const el = event.target.closest( '.stk-block-expand' )
 
@@ -15,6 +17,12 @@ class StackableExpand {
 			hiddens.forEach( el => el.setAttribute( 'aria-hidden', 'false' ) )
 			visibles.forEach( el => el.setAttribute( 'aria-hidden', 'true' ) )
 
+			const expanded = el.querySelector( '[aria-expanded="true"]' )
+			const collapsed = el.querySelector( '[aria-expanded="false"]' )
+
+			expanded.setAttribute( 'aria-expanded', 'false' )
+			collapsed.setAttribute( 'aria-expanded', 'true' )
+
 			// Refocus on the hide/show button.
 			el.querySelector( `.stk-button[aria-hidden="false"]` ).focus( {
 				preventScroll: true,
@@ -22,8 +30,26 @@ class StackableExpand {
 
 			event.preventDefault()
 		}
+
+		const addAriaAttributes = el => {
+			const shortText = el.querySelector( '.stk-block-expand__short-text' )
+			const showBtn = el.querySelector( '.stk-block-expand__show-button > .stk-button' )
+			const moreText = el.querySelector( '.stk-block-expand__more-text' )
+			const hideBtn = el.querySelector( '.stk-block-expand__hide-button > .stk-button' )
+
+			shortText.setAttribute( 'id', shortText.getAttribute( 'data-block-id' ) )
+			moreText.setAttribute( 'id', moreText.getAttribute( 'data-block-id' ) )
+
+			showBtn.setAttribute( 'aria-controls', shortText.getAttribute( 'data-block-id' ) )
+			hideBtn.setAttribute( 'aria-controls', moreText.getAttribute( 'data-block-id' ) )
+		}
+
 		els.forEach( el => {
 			el.addEventListener( 'click', onClick )
+		} )
+
+		blocks.forEach( block => {
+			addAriaAttributes( block )
 		} )
 	}
 }

--- a/src/block/expand/frontend-expand.js
+++ b/src/block/expand/frontend-expand.js
@@ -17,12 +17,6 @@ class StackableExpand {
 			hiddens.forEach( el => el.setAttribute( 'aria-hidden', 'false' ) )
 			visibles.forEach( el => el.setAttribute( 'aria-hidden', 'true' ) )
 
-			const expanded = el.querySelector( '[aria-expanded="true"]' )
-			const collapsed = el.querySelector( '[aria-expanded="false"]' )
-
-			expanded.setAttribute( 'aria-expanded', 'false' )
-			collapsed.setAttribute( 'aria-expanded', 'true' )
-
 			// Refocus on the hide/show button.
 			el.querySelector( `.stk-button[aria-hidden="false"]` ).focus( {
 				preventScroll: true,

--- a/src/block/expand/frontend-expand.js
+++ b/src/block/expand/frontend-expand.js
@@ -38,11 +38,18 @@ class StackableExpand {
 			hideBtn.setAttribute( 'aria-controls', moreText.getAttribute( 'data-block-id' ) )
 		}
 
+		const fixAriaAttributes = el => {
+			if ( el.hasAttribute( 'aria-expanded' ) ) {
+				el.removeAttribute( 'aria-expanded' )
+			}
+		}
+
 		els.forEach( el => {
 			el.addEventListener( 'click', onClick )
 		} )
 
 		blocks.forEach( block => {
+			fixAriaAttributes( block )
 			addAriaAttributes( block )
 		} )
 	}

--- a/src/block/expand/frontend-expand.js
+++ b/src/block/expand/frontend-expand.js
@@ -8,8 +8,6 @@ class StackableExpand {
 		const els = document.querySelectorAll( '.stk-block-expand .stk-button' )
 		const onClick = event => {
 			const el = event.target.closest( '.stk-block-expand' )
-			const expanded = el.getAttribute( 'aria-expanded' ) === 'true'
-			el.setAttribute( 'aria-expanded', ! expanded )
 
 			// Invert the hidden text.
 			const visibles = el.querySelectorAll( '[aria-hidden="false"]' )

--- a/src/block/expand/schema.js
+++ b/src/block/expand/schema.js
@@ -34,7 +34,7 @@ export const attributes = ( version = VERSION ) => {
 			customAttributes: [ [ 'aria-expanded', 'false' ] ],
 		},
 		versionAdded: '3.0.0',
-		versionDeprecated: '3.9.0',
+		versionDeprecated: '3.9.1',
 	} )
 
 	return attrObject.getMerged( version )

--- a/src/block/expand/schema.js
+++ b/src/block/expand/schema.js
@@ -30,9 +30,7 @@ export const attributes = ( version = VERSION ) => {
 	ConditionalDisplay.addAttributes( attrObject )
 
 	attrObject.addDefaultValues( {
-		attributes: {
-			customAttributes: [ [ 'aria-expanded', 'false' ] ],
-		},
+		attributes: {},
 		versionAdded: '3.0.0',
 		versionDeprecated: '',
 	} )

--- a/src/block/expand/schema.js
+++ b/src/block/expand/schema.js
@@ -30,9 +30,11 @@ export const attributes = ( version = VERSION ) => {
 	ConditionalDisplay.addAttributes( attrObject )
 
 	attrObject.addDefaultValues( {
-		attributes: {},
+		attributes: {
+			customAttributes: [ [ 'aria-expanded', 'false' ] ],
+		},
 		versionAdded: '3.0.0',
-		versionDeprecated: '',
+		versionDeprecated: '3.9.0',
 	} )
 
 	return attrObject.getMerged( version )


### PR DESCRIPTION
fixes #2617 

- removed custom attributes aria-expanded in Expand / Show More block