### PR TITLE
Removed WordPress versions prior to 6.0 in php-5.6.39.yml, php-7.3.5.yml and php-8.0.0.yml

### DIFF
--- a/.github/workflows/php-5.6.39.yml
+++ b/.github/workflows/php-5.6.39.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        wp-versions: ['5.8.5', '5.9.4', '6.0.2']
+        wp-versions: ['6.0.2']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/php-7.3.5.yml
+++ b/.github/workflows/php-7.3.5.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        wp-versions: ['5.8.5', '5.9.4', '6.0.2']
+        wp-versions: ['6.0.2']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/php-8.0.0.yml
+++ b/.github/workflows/php-8.0.0.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        wp-versions: ['5.8.5', '5.9.4', '6.0.2']
+        wp-versions: ['6.0.2']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Hello @bfintal 

Removed WordPress versions prior to 6.0 in php-5.6.39.yml, php-7.3.5.yml and php-8.0.0.yml

Also, I take this opportunity to point out that [Node.js version 14.x is "end-of-life" as of April 30, 2023](https://github.com/nodejs/release#end-of-life-releases).