### PR TITLE
fix (carousel): removed scrollbar visibility in Mozilla Firefox

### DIFF
--- a/src/block/carousel/editor.scss
+++ b/src/block/carousel/editor.scss
@@ -1,6 +1,8 @@
 @import "common";
 
 .stk-block-carousel__slider {
+	scrollbar-width: none; // Removes scrollbar visibility in Mozilla Firefox
+
 	// Column outlines should be offset inside or else they will be cut.
 	> .block-editor-inner-blocks > .block-editor-block-list__layout {
 		> [data-type="stackable/column"] {

--- a/src/block/carousel/style.scss
+++ b/src/block/carousel/style.scss
@@ -34,6 +34,7 @@
 	margin: 0 auto;
 	position: relative;
 	overflow: hidden;
+	scrollbar-width: none; // Removes scrollbar visibility in Mozilla Firefox
 }
 .stk-block-carousel__slider-wrapper {
 	position: relative;


### PR DESCRIPTION
fixes #2701 