### PR TITLE
fix (inner-column): prevent margin bottom visual indicator from overlapping with the block

### DIFF
--- a/src/styles/editor-block.scss
+++ b/src/styles/editor-block.scss
@@ -237,9 +237,6 @@
 	// Last of type since there's a .block-list-appender
 	> [data-block]:nth-last-child(2) {
 		margin-bottom: 0;
-		&[data-type^="stackable/"] > .stk-block {
-			margin-bottom: 0;
-		}
 	}
 	> [data-block]:first-child:last-child {
 		margin-bottom: 0;

--- a/src/styles/editor-block.scss
+++ b/src/styles/editor-block.scss
@@ -235,8 +235,11 @@
 		margin-top: 0;
 	}
 	// Last of type since there's a .block-list-appender
-	> [data-block]:nth-last-child(2) {
+	&:is([data-is-drop-zone="true"]) > [data-block]:nth-last-child(2) {
 		margin-bottom: 0;
+		&[data-type^="stackable/"] > .stk-block {
+			margin-bottom: 0;
+		}
 	}
 	> [data-block]:first-child:last-child {
 		margin-bottom: 0;

--- a/src/styles/editor-block.scss
+++ b/src/styles/editor-block.scss
@@ -235,6 +235,7 @@
 		margin-top: 0;
 	}
 	// Last of type since there's a .block-list-appender
+	// If the block parent is locked, there will be no appender block and data-is-drop-zone will not be present.
 	&:is([data-is-drop-zone="true"]) > [data-block]:nth-last-child(2) {
 		margin-bottom: 0;
 		&[data-type^="stackable/"] > .stk-block {


### PR DESCRIPTION
fixes #2672 