### PR TITLE
fix (WP6.3): prevent design library from being covered by the "Top toolbar"

### DIFF
--- a/src/plugins/design-library-button/editor.scss
+++ b/src/plugins/design-library-button/editor.scss
@@ -1,3 +1,9 @@
 .ugb-insert-library-button {
 	white-space: nowrap;
 }
+
+.has-fixed-toolbar {
+	.ugb-insert-library-button {
+		margin-left: 70px;
+	}
+}


### PR DESCRIPTION
fixes #2770 