### PR TITLE
fix: removes extra divider in top toolbar

### DIFF
--- a/src/editor.scss
+++ b/src/editor.scss
@@ -63,6 +63,11 @@ svg.stk-stackable-icon-gradient {
 	}
 }
 
+// removes extra divider in Top Toolbar
+.components-toolbar.block-editor-block-toolbar__block-controls::after {
+	content: none !important;
+}
+
 /**
  * Thicker column (blue) outlines for container-type blocks.
  */


### PR DESCRIPTION
fixes #2803 