### PR TITLE
fix (columns): content max width unit is saved upon editor refresh

### DIFF
--- a/src/block/columns/schema.js
+++ b/src/block/columns/schema.js
@@ -59,6 +59,7 @@ export const attributes = ( version = VERSION ) => {
 				stkResponsive: true,
 				type: 'number',
 				default: '',
+				stkUnits: 'px',
 			},
 			containerHorizontalAlign: {
 				stkResponsive: true,


### PR DESCRIPTION
fixes #2826 