### PR TITLE
fix (accordion): prevent viewport from scrolling lower when closing an accordion with large content.

### DIFF
--- a/src/block/accordion/frontend-accordion.js
+++ b/src/block/accordion/frontend-accordion.js
@@ -90,6 +90,20 @@ class StackableAccordion {
 						adjacent = adjacent.previousElementSibling
 					}
 				}
+
+				// If an accordion with large content is closed while opening
+				// another accordion, it scrolls downwards.
+				// This is to instantly scroll to the opening accordion.
+				if ( el.open ) {
+					const isAboveView = el.getBoundingClientRect().top < 0
+					if ( isAboveView ) {
+						el.scrollIntoView( {
+							inline: 'start',
+							block: 'start',
+							behavior: 'instant',
+						} )
+					}
+				}
 			} )
 		} )
 


### PR DESCRIPTION
fixes #2726 