### PR TITLE
fix (icon-label): icon gap responsive values are saved in the backend

### DIFF
--- a/src/block/icon-label/schema.js
+++ b/src/block/icon-label/schema.js
@@ -34,6 +34,7 @@ export const attributes = ( version = VERSION ) => {
 		attributes: {
 			iconGap: {
 				type: 'number',
+				stkResponsive: true,
 				default: '',
 			},
 		},


### PR DESCRIPTION
fixes #2670 