### PR TITLE
fix: remove spacing support if wp < 6.3

### DIFF
--- a/src/compatibility/index.js
+++ b/src/compatibility/index.js
@@ -1,1 +1,2 @@
 import './kadence-theme'
+import './wp-6-2'

--- a/src/compatibility/wp-6-2/index.js
+++ b/src/compatibility/wp-6-2/index.js
@@ -1,0 +1,18 @@
+
+/**
+ * Internal dependncies
+ */
+import { semverCompare } from '~stackable/util'
+import { wpVersion } from 'stackable'
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks'
+
+addFilter( 'stackable.block.metadata', 'stackable/wp-6-2', settings => {
+	if ( wpVersion && semverCompare( wpVersion, '<', '6.3' ) && settings?.supports?.spacing ) {
+		delete settings.supports.spacing
+	}
+	return settings
+} )

--- a/src/util/blocks.js
+++ b/src/util/blocks.js
@@ -4,7 +4,6 @@
 import { loadGoogleFontInAttributes } from './font'
 import { moveArrayIndex } from '.'
 import { SVGStackableCategoryIcon } from '~stackable/icons'
-import { semverCompare } from '~stackable/util'
 
 /**
  * External dependencies
@@ -14,9 +13,7 @@ import {
 	orderBy,
 	last,
 } from 'lodash'
-import {
-	blockCategoryIndex, i18n, wpVersion,
-} from 'stackable'
+import { blockCategoryIndex, i18n } from 'stackable'
 
 /**
  * WordPress dependencies
@@ -479,10 +476,6 @@ export const addStackableBlockCategory = () => {
  * @param {Object} _settings The block properties to register
  */
 export const registerBlockType = ( name, _settings ) => {
-	if ( wpVersion && semverCompare( wpVersion, '<', '6.3' ) && _settings?.supports?.spacing ) {
-		delete _settings.supports.spacing
-	}
-
 	let settings = applyFilters( `stackable.block.metadata`, _settings || {} )
 
 	// If there is no variation title, then some labels in the editor will show

--- a/src/util/blocks.js
+++ b/src/util/blocks.js
@@ -4,6 +4,7 @@
 import { loadGoogleFontInAttributes } from './font'
 import { moveArrayIndex } from '.'
 import { SVGStackableCategoryIcon } from '~stackable/icons'
+import { semverCompare } from '~stackable/util'
 
 /**
  * External dependencies
@@ -13,7 +14,9 @@ import {
 	orderBy,
 	last,
 } from 'lodash'
-import { blockCategoryIndex, i18n } from 'stackable'
+import {
+	blockCategoryIndex, i18n, wpVersion,
+} from 'stackable'
 
 /**
  * WordPress dependencies
@@ -476,6 +479,10 @@ export const addStackableBlockCategory = () => {
  * @param {Object} _settings The block properties to register
  */
 export const registerBlockType = ( name, _settings ) => {
+	if ( wpVersion && semverCompare( wpVersion, '<', '6.3' ) && _settings?.supports?.spacing ) {
+		delete _settings.supports.spacing
+	}
+
 	let settings = applyFilters( `stackable.block.metadata`, _settings || {} )
 
 	// If there is no variation title, then some labels in the editor will show


### PR DESCRIPTION
fixes #2837 
fixes #2828 