### PR TITLE
fix (wp 6.0): backward compatibility if wp.element.createRoot is not available

### DIFF
--- a/eslint/index.js
+++ b/eslint/index.js
@@ -7,6 +7,7 @@ module.exports = {
 		'no-deprecated-use-styles': require( './rules/no-deprecated-use-styles' ),
 		'no-get-block-parents': require( './rules/no-get-block-parents' ),
 		'no-use-dispatch': require( './rules/no-use-dispatch' ),
+		'no-import-create-root': require( './rules/no-import-create-root' ),
 	},
 	configs: {
 		recommended: {
@@ -21,6 +22,7 @@ module.exports = {
 				'stackable/no-deprecated-use-styles': 'error',
 				'stackable/no-get-block-parents': 'error',
 				'stackable/no-use-dispatch': 'error',
+				'stackable/no-import-create-root': 'error',
 			},
 		},
 	},

--- a/eslint/readme.md
+++ b/eslint/readme.md
@@ -1,0 +1,10 @@
+# Custom Stackable ESLint Rules
+
+These ESLint rules are specific to the Stackable codebase. These rules should:
+
+- Show us the correct or preferred approach when developing for Stackable
+- Prevent us from repeating past mistakes
+
+# Contributing
+
+When creating new rules, use the [AST Explorer](https://astexplorer.net/) to help out during the creation.

--- a/eslint/rules/no-import-create-root.js
+++ b/eslint/rules/no-import-create-root.js
@@ -1,0 +1,46 @@
+/**
+ * In `src/welcome` and `src/admin`, importing the base module/library via `~stackable/components` will unnecessarily import the entire library and will dramatically increase the compiled script. Instead, import the component that's needed directly:
+ *
+ * ```js
+ * // Invalid:
+ * // import { AdminToggleSetting } from '~stackable/components'
+ *
+ * // Valid:
+ * import AdminToggleSetting from '~stackable/components/admin-toggle-setting'
+ * ```
+ *
+ * @see https://github.com/gambitph/Stackable/pull/2333#user-content-no-import-stk-full-library
+ */
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'disallow using of wp.element.createRoot',
+			recommended: true,
+			// url: 'https://github.com/gambitph/Stackable/pull/2333#user-content-no-import-stk-full-library',
+		},
+	},
+	create: context => {
+		return ( {
+			ImportDeclaration: node => { // AST Node Type
+				if ( node.source && node.source.type === 'Literal' && node.source.value === '@wordpress/element' ) {
+					node.specifiers.some( specifier => {
+						if ( specifier.imported.name === 'createRoot' ) {
+							context.report( {
+								node,
+								message: 'Do not import \'{{ identifier }}\' from \'{{ source }}\', instead import \'{{ identifier }}\' from \'{{ stackableSource }}\'. See link for more details.',
+								data: {
+									identifier: specifier.imported.name,
+									source: node.source.value,
+									stackableSource: '~stackable/util',
+								},
+							} )
+							return true
+						}
+						return false
+					} )
+				}
+			},
+		} )
+	},
+}

--- a/eslint/rules/no-import-create-root.js
+++ b/eslint/rules/no-import-create-root.js
@@ -1,15 +1,19 @@
 /**
- * In `src/welcome` and `src/admin`, importing the base module/library via `~stackable/components` will unnecessarily import the entire library and will dramatically increase the compiled script. Instead, import the component that's needed directly:
+ * `wp.element.render` has been deprecated in WP 6.2 and was replaced by
+ * `wp.element.createRoot`. In order to preserve backward compatibility of
+ * Stackable with 6.0 and 6.1, we need to stub `createRoot` to fallback to using
+ * `wp.element.render` internally.
  *
  * ```js
  * // Invalid:
- * // import { AdminToggleSetting } from '~stackable/components'
+ * // import { createRoot } from '@wordpress/element'
  *
  * // Valid:
- * import AdminToggleSetting from '~stackable/components/admin-toggle-setting'
- * ```
+ * import { createRoot } from '~stackable/util'
+ * import { createRoot } from '~stackable/util/element'
  *
- * @see https://github.com/gambitph/Stackable/pull/2333#user-content-no-import-stk-full-library
+ * @see
+ * https://github.com/gambitph/Stackable/pull/2856#user-content-no-import-create-root
  */
 module.exports = {
 	meta: {
@@ -17,7 +21,7 @@ module.exports = {
 		docs: {
 			description: 'disallow using of wp.element.createRoot',
 			recommended: true,
-			// url: 'https://github.com/gambitph/Stackable/pull/2333#user-content-no-import-stk-full-library',
+			url: 'https://github.com/gambitph/Stackable/pull/2856#user-content-no-import-create-root',
 		},
 	},
 	create: context => {

--- a/eslint/rules/no-import-stk-full-library.js
+++ b/eslint/rules/no-import-stk-full-library.js
@@ -25,7 +25,9 @@ module.exports = {
 		return ( {
 			ImportDeclaration: node => { // AST Node Type
 				if ( node.source && node.source.type === 'Literal' ) {
-					if ( fullPath.includes( '/src/welcome/' ) || fullPath.includes( '/src/admin/' ) ) {
+					if ( fullPath.includes( '/src/welcome/' ) || fullPath.includes( '/src/admin/' ) ||
+					     ( fullPath.includes( '/src/deprecated/' ) && fullPath.includes( '/welcome/' ) )
+					) {
 						if ( node.source.value && node.source.value.startsWith( '~stackable/' ) ) {
 							if ( node.source.value.match( /^~stackable\/[\w-]+\/?$/ ) ) {
 								context.report( {

--- a/src/components/custom-attributes-control/index.js
+++ b/src/components/custom-attributes-control/index.js
@@ -5,12 +5,16 @@ import { i18n } from 'stackable'
 import { escape as _escape } from 'lodash'
 
 /**
+ * Internal dependencies
+ */
+import { createRoot } from '~stackable/util'
+
+/**
  * WordPress dependencies
  */
 import {
 	Fragment,
 	useState,
-	createRoot,
 	unmountComponentAtNode,
 	useRef,
 } from '@wordpress/element'

--- a/src/deprecated/v2/welcome/admin.js
+++ b/src/deprecated/v2/welcome/admin.js
@@ -8,7 +8,7 @@ import blockData from './blocks'
  */
 import { __ } from '@wordpress/i18n'
 import {
-	Component, createRoot, useEffect, useState, Fragment,
+	Component, useEffect, useState, Fragment,
 } from '@wordpress/element'
 import { send as ajaxSend } from '@wordpress/ajax'
 import domReady from '@wordpress/dom-ready'
@@ -24,6 +24,7 @@ import {
 	v2nonce as nonce,
 } from 'stackable'
 import AdminToggleSetting from '~stackable/components/admin-toggle-setting'
+import { createRoot } from '~stackable/util/element'
 
 class BlockToggler extends Component {
 	constructor() {

--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -53,9 +53,14 @@ import SVGVideoPopupIcon from './images/video-popup-icon.svg'
 import SVGUngroupContainerIcon from './images/ungroup-container-icon.svg'
 
 /**
+ * Internal dependencies
+ */
+import { createRoot } from '~stackable/util'
+
+/**
  * WordPress dependencies
  */
-import { cloneElement, createRoot } from '@wordpress/element'
+import { cloneElement } from '@wordpress/element'
 import domReady from '@wordpress/dom-ready'
 
 export function colorizeIcon( SvgIcon ) {

--- a/src/plugins/design-library-button/index.js
+++ b/src/plugins/design-library-button/index.js
@@ -7,12 +7,12 @@ import { isContentOnlyMode } from 'stackable'
  * Internal dependencies
  */
 import DesignLibraryButton from './design-library-button'
+import { createRoot } from '~stackable/util'
 
 /**
  * WordPress dependencies
  */
 import domReady from '@wordpress/dom-ready'
-import { createRoot } from '@wordpress/element'
 import { subscribe } from '@wordpress/data'
 
 const mountDesignLibrary = () => {

--- a/src/plugins/global-settings/editor-loader.js
+++ b/src/plugins/global-settings/editor-loader.js
@@ -13,11 +13,12 @@ import './block-defaults'
  * External dependencies
  */
 import { useDeviceType } from '~stackable/hooks'
+import { createRoot } from '~stackable/util'
 
 /** WordPress dependencies
  */
 import { registerPlugin } from '@wordpress/plugins'
-import { createRoot, useEffect } from '@wordpress/element'
+import { useEffect } from '@wordpress/element'
 import { __ } from '@wordpress/i18n'
 import { useSelect } from '@wordpress/data'
 import domReady from '@wordpress/dom-ready'

--- a/src/plugins/theme-block-size/index.js
+++ b/src/plugins/theme-block-size/index.js
@@ -4,9 +4,10 @@
  * properties for our blocks to pick up in the editor.
  */
 import { useDeviceType } from '~stackable/hooks'
+import { createRoot } from '~stackable/util'
 import { useSetting } from '@wordpress/block-editor'
 import domReady from '@wordpress/dom-ready'
-import { createRoot, useEffect } from '@wordpress/element'
+import { useEffect } from '@wordpress/element'
 import { useSelect } from '@wordpress/data'
 
 export const ThemeBlockSize = () => {

--- a/src/util/element.js
+++ b/src/util/element.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+// eslint-disable-next-line stackable/no-import-create-root
+import { createRoot as _createRoot } from '@wordpress/element'
+
+/**
+ * A backward compatible createRoot function (for WP 6.1 and below), this mimics
+ * the createRoot function. Use this instead of wp.element.createRoot
+ *
+ * @see https://react.dev/reference/react-dom/client/createRoot
+ *
+ * @param {DOMElement} el
+ * @return {Object} Object with a render and unmount function
+ */
+export const createRoot = el => {
+	// If WP 6.2 and above, use the createRoot function.
+	if ( _createRoot ) {
+		return _createRoot( el )
+	}
+
+	// If WP 6.1 and below, mimic how it works.
+	return {
+		render: reactNode => {
+			return wp.element.render( reactNode, el )
+		},
+		unmount: () => {
+			return wp.element.unmountComponentAtNode( el )
+		},
+	}
+}

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -15,6 +15,7 @@ export * from './icon'
 export * from './fontawesome'
 export * from './user'
 export * from './colors'
+export * from './element'
 
 /**
  * WordPress dependencies

--- a/src/welcome/admin.js
+++ b/src/welcome/admin.js
@@ -11,7 +11,7 @@ import SVGSectionIcon from './images/settings-icon-section.svg'
  */
 import { __ } from '@wordpress/i18n'
 import {
-	createRoot, useEffect, useState, Fragment, useCallback,
+	useEffect, useState, Fragment, useCallback,
 } from '@wordpress/element'
 import domReady from '@wordpress/dom-ready'
 import { Spinner, CheckboxControl } from '@wordpress/components'
@@ -27,6 +27,7 @@ import {
 } from 'stackable'
 import classnames from 'classnames'
 import { importBlocks } from '~stackable/util/admin'
+import { createRoot } from '~stackable/util/element'
 import AdminToggleSetting from '~stackable/components/admin-toggle-setting'
 import AdminTextSetting from '~stackable/components/admin-text-setting'
 import { GettingStarted } from './getting-started'

--- a/src/welcome/news.js
+++ b/src/welcome/news.js
@@ -3,8 +3,8 @@
  */
 import { send as ajaxSend } from '@wordpress/ajax'
 import domReady from '@wordpress/dom-ready'
-import { createRoot } from '@wordpress/element'
 import { Spinner } from '@wordpress/components'
+import { createRoot } from '~stackable/util/element'
 
 /**
  * External dependencies


### PR DESCRIPTION
Fixes #2857

# Introduced eslint rules

## eslint rule: <a id="no-import-create-root">no-import-create-root</a>

`wp.element.render` has been deprecated in WP 6.2 and was replaced by `wp.element.createRoot`. In order to preserve backward compatibility of Stackable with 6.0 and 6.1, we need to stub `createRoot` to fallback to using `wp.element.render` internally.

```js
// Do not use wp.element.createRoot
// import { createRoot } from '@wordpress/element'
import { createRoot } from '~stackable/util'
or
import { createRoot } from '~stackable/util/element'
```