### PR TITLE
fix (feature-grid): column arrangement's responsive values do not disappear on refresh

### DIFF
--- a/src/block/feature-grid/schema.js
+++ b/src/block/feature-grid/schema.js
@@ -35,6 +35,18 @@ export const attributes = ( version = VERSION ) => {
 	Separator.addAttributes( attrObject )
 	ContentAlign.addAttributes( attrObject )
 
+	attrObject.add( {
+		attributes: {
+			columnArrangement: {
+				stkResponsive: true,
+				type: 'string',
+				default: '',
+			},
+		},
+		versionAdded: '3.0.0',
+		versionDeprecated: '',
+	} )
+
 	attrObject.addDefaultValues( {
 		attributes: {
 			contentAlign: 'center',


### PR DESCRIPTION
fixes #2706 