### PR TITLE
chore (workflow): Changed WordPress version to 6.2.4 in php-5.6.39.yml, php-7.3.5.yml and php-8.0.0.yml

### DIFF
--- a/.github/workflows/php-5.6.39.yml
+++ b/.github/workflows/php-5.6.39.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        wp-versions: ['6.1.3']
+        wp-versions: ['6.1.4']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/php-5.6.39.yml
+++ b/.github/workflows/php-5.6.39.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        wp-versions: ['6.0.2']
+        wp-versions: ['6.1.3']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/php-5.6.39.yml
+++ b/.github/workflows/php-5.6.39.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        wp-versions: ['6.1.4']
+        wp-versions: ['6.2.4']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/php-7.3.5.yml
+++ b/.github/workflows/php-7.3.5.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        wp-versions: ['6.1.4']
+        wp-versions: ['6.2.4']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/php-7.3.5.yml
+++ b/.github/workflows/php-7.3.5.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        wp-versions: ['6.0.2']
+        wp-versions: ['6.1.3']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/php-7.3.5.yml
+++ b/.github/workflows/php-7.3.5.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        wp-versions: ['6.1.3']
+        wp-versions: ['6.1.4']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/php-8.0.0.yml
+++ b/.github/workflows/php-8.0.0.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        wp-versions: ['6.0.2']
+        wp-versions: ['6.1.3']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/php-8.0.0.yml
+++ b/.github/workflows/php-8.0.0.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        wp-versions: ['6.1.4']
+        wp-versions: ['6.2.4']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/php-8.0.0.yml
+++ b/.github/workflows/php-8.0.0.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        wp-versions: ['6.1.3']
+        wp-versions: ['6.1.4']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Hello @bfintal 

Changed WordPress version to <del>6.1.3</del> <del>6.1.4</del> 6.2.4 in php-5.6.39.yml, php-7.3.5.yml and php-8.0.0.yml

Also, I take this opportunity to point out that [Node.js version 14.x is "end-of-life" as of April 30, 2023](https://github.com/nodejs/release#end-of-life-releases).