### PR TITLE
fix (timeline block): align dot if background is enabled in mobile

### DIFF
--- a/src/block/timeline/style.js
+++ b/src/block/timeline/style.js
@@ -171,7 +171,7 @@ const Styles = props => {
 					const getInherited = true
 					const padding = getAttribute( 'blockPadding', device, 'normal', getInherited )
 					if ( device === 'mobile' ) {
-						return `${ padding?.top }px` || ''
+						return padding ? `${ padding?.top }px` : ''
 					}
 					return ''
 				} }

--- a/src/block/timeline/style.scss
+++ b/src/block/timeline/style.scss
@@ -125,9 +125,6 @@
 	.stk-block-timeline > .stk-inner-blocks::after {
 		inset-inline-start: calc(var(--line-dot-size, 16px) / 2 - var(--line-bg-width, 3px) / 2 + 16px);
 	}
-	.stk-block-timeline.stk-block-background .stk-block-timeline__middle {
-		margin-left: -16px;
-	}
 	.stk-block-timeline .stk-block-timeline__middle {
 		position: absolute;
 		inset-inline-start: 16px;


### PR DESCRIPTION
fixes #2863 