### PR TITLE
fix (spacer): prevent block border and resize border from misaligning when resizing 

### DIFF
--- a/src/block/spacer/style.js
+++ b/src/block/spacer/style.js
@@ -27,6 +27,7 @@ const Styles = props => {
 			<BlockCss
 				{ ...propsToPass }
 				selector=""
+				renderIn="save"
 				styleRule="height"
 				attrName="height"
 				key="height"


### PR DESCRIPTION
fixes #2866 