### PR TITLE
Fix: apply global typography settings even when switching between visual/code editors

### DIFF
--- a/src/plugins/get-editor-dom/index.js
+++ b/src/plugins/get-editor-dom/index.js
@@ -38,6 +38,11 @@ export const EditorDom = () => {
 		return select( 'core/edit-site' )?.getEditedPostId?.()
 	} )
 
+	// When switching between visual editor and code editor, the editor is recreated
+	const editorMode = useSelect( select => {
+		return select( 'core/edit-site' )?.getEditorMode() || select( 'core/edit-post' )?.getEditorMode()
+	} )
+
 	useEffect( () => {
 		// If the editor is available right away, use it.
 		const editorEl = document.querySelector( `.editor-styles-wrapper, iframe[name="editor-canvas"]` )
@@ -93,7 +98,7 @@ export const EditorDom = () => {
 			clearInterval( interval.current )
 			clearTimeout( timeout.current )
 		}
-	}, [ deviceType, editedSitePostId ] )
+	}, [ deviceType, editorMode, editedSitePostId ] )
 
 	useMemo( () => {
 		const iframeEl = document.querySelector( `iframe[name="editor-canvas"]` )

--- a/src/plugins/global-settings/typography/editor-loader.js
+++ b/src/plugins/global-settings/typography/editor-loader.js
@@ -46,6 +46,11 @@ export const GlobalTypographyStyles = () => {
 		[]
 	)
 
+	// when switching between visual editor and code editor, the font family needs to be reloaded
+	const editorMode = useSelect( select => {
+		return select( 'core/edit-site' )?.getEditorMode() || select( 'core/edit-post' )?.getEditorMode()
+	} )
+
 	useEffect( () => {
 		// Get settings.
 		fetchSettings().then( response => {
@@ -115,7 +120,7 @@ export const GlobalTypographyStyles = () => {
 		setStyleTimeout( setTimeout( () => doAction( 'stackable.global-settings.typography-update-global-styles', typographySettings ), 200 ) )
 
 		return () => removeAction( 'stackable.global-settings.typography-update-global-styles', 'stackable/typography-styles' )
-	}, [ JSON.stringify( typographySettings ), applySettingsTo, device ] )
+	}, [ JSON.stringify( typographySettings ), applySettingsTo, device, editorMode ] )
 
 	return styles
 }


### PR DESCRIPTION
fixes #2855 