### PR TITLE
fix: timeline lines on iOS devices

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -225,6 +225,7 @@ if ( ! is_admin() ) {
 	require_once( plugin_dir_path( __FILE__ ) . 'src/block/tabs/index.php' );
 	require_once( plugin_dir_path( __FILE__ ) . 'src/block-components/alignment/index.php' );
 	require_once( plugin_dir_path( __FILE__ ) . 'src/block/columns/index.php' );
+	require_once( plugin_dir_path( __FILE__ ) . 'src/block/timeline/index.php' );
 }
 
 /**

--- a/src/block/timeline/index.php
+++ b/src/block/timeline/index.php
@@ -17,7 +17,9 @@ if ( ! function_exists( 'stackable_load_timeline_ios_frontend_polyfill' ) ) {
 
 	$user_agent = ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
 	// Add polyfill if device is iPhone/iPad
-	if ( ! empty( $user_agent ) && ( stripos( $user_agent, 'iPhone' ) !== false || stripos( $user_agent, 'iPad' ) !== false ) ) {
+	// Include Safari because by default the User Agent in Safari on iPadOS is same  on MacOS
+	// Reference: https://developer.apple.com/forums/thread/119186
+	if ( ! empty( $user_agent ) && ( stripos( $user_agent, 'iPhone' ) !== false || stripos( $user_agent, 'iPad' ) !== false || stripos( $user_agent, 'Safari/' ) !== false ) ) {
 		add_filter( 'render_block_stackable/timeline', 'stackable_load_timeline_ios_frontend_polyfill', 10, 2 );
 	}
 }

--- a/src/block/timeline/index.php
+++ b/src/block/timeline/index.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * In charge of loading the frontend polyfill for timeline block
+ * accent color fill for iOS devices
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! function_exists( 'stackable_load_timeline_ios_frontend_polyfill' ) ) {
+	function stackable_load_timeline_ios_frontend_polyfill( $block_content, $block ) {
+		// Add class stk-block-timeline__ios-polyfill to $block_content
+		return preg_replace( '/stk-block-timeline/', 'stk-block-timeline stk-block-timeline__ios-polyfill', $block_content, 1 );
+	}
+
+	$user_agent = ! empty( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
+	// Add polyfill if device is iPhone/iPad
+	if ( ! empty( $user_agent ) && ( stripos( $user_agent, 'iPhone' ) !== false || stripos( $user_agent, 'iPad' ) !== false ) ) {
+		add_filter( 'render_block_stackable/timeline', 'stackable_load_timeline_ios_frontend_polyfill', 10, 2 );
+	}
+}

--- a/src/block/timeline/style.scss
+++ b/src/block/timeline/style.scss
@@ -21,9 +21,11 @@
 }
 
 // iOS polyfill for timeline accent color
-// fill timeline lines filled with accent color
-.stk-block-timeline.stk-block-timeline__ios-polyfill {
-	--fixed-bg: linear-gradient(to bottom, var(--line-accent-bg-color, #000) 0, var(--line-accent-bg-color-2, #000) var(--line-accent-bg-location, 50%));
+// For tablet and mobile, fill timeline lines with accent color
+@include tablet-mobile {
+	.stk-block-timeline.stk-block-timeline__ios-polyfill {
+		--fixed-bg: linear-gradient(to bottom, var(--line-accent-bg-color, #000) 0, var(--line-accent-bg-color-2, #000) var(--line-accent-bg-location, 50%));
+	}
 }
 
 // Remove the default bottom margin of the timeline block because it's annoying

--- a/src/block/timeline/style.scss
+++ b/src/block/timeline/style.scss
@@ -19,6 +19,13 @@
 	padding: 16px 0;
 	margin-block-start: 0 !important;
 }
+
+// iOS polyfill for timeline accent color
+// fill timeline lines filled with accent color
+.stk-block-timeline.stk-block-timeline__ios-polyfill {
+	--fixed-bg: linear-gradient(to bottom, var(--line-accent-bg-color, #000) 0, var(--line-accent-bg-color-2, #000) var(--line-accent-bg-location, 50%));
+}
+
 // Remove the default bottom margin of the timeline block because it's annoying
 // to keep on removing it when you want to stack them. This works in conjunction
 // with the stackable.resizable-bottom-margin.default filter in edit.js.


### PR DESCRIPTION
fixes #2912 

Timeline block uses `background-attachment: fixed` for the timeline lines' scrolling effect. However, it is currently not supported by iOS/iPadOS as discussed in this [thread](https://developer.apple.com/forums/thread/99883).

This fix now fills timeline lines (for iOS devices only) so that for pages with many consecutive timeline blocks it won't look broken like this:

https://github.com/gambitph/Stackable/assets/98727316/fce98493-2ba8-4127-97b5-5bc319584e20

Instead, it will now look like this:

https://github.com/gambitph/Stackable/assets/98727316/f9e1f3e7-7cc0-490d-adc3-bcfed9584b8a