### PR TITLE
fix (WP 6.4): removed enter icon in link search control

### DIFF
--- a/src/components/link-control/editor.scss
+++ b/src/components/link-control/editor.scss
@@ -53,7 +53,16 @@
 	}
 
 	.block-editor-link-control__search-enter {
-		display: none;
+		position: absolute;
+		top: 0;
+		right: 3px;
+		button:hover {
+			box-shadow: none !important;
+		}
+		svg {
+			height: 20px;
+			width: 20px;
+		}
 	}
 }
 

--- a/src/components/link-control/editor.scss
+++ b/src/components/link-control/editor.scss
@@ -51,6 +51,10 @@
 	.block-editor-link-control__search-item-icon {
 		display: none;
 	}
+
+	.block-editor-link-control__search-enter {
+		display: none;
+	}
 }
 
 // Adjust the location of the dynamic and reset buttons since our control is taller.


### PR DESCRIPTION
fixes #2936 