### PR TITLE
fix (WP 6.4): removed non labeled option in post type selection of the posts block

### DIFF
--- a/src/components/taxonomy-control/index.js
+++ b/src/components/taxonomy-control/index.js
@@ -72,6 +72,10 @@ class TaxonomyControl extends Component {
 				taxonomies,
 			} = this.state.termList[ postType ]
 
+			if ( postType === 'wp_block' ) {
+				return
+			}
+
 			postTypeOptions.push( {
 				label,
 				value: postType,


### PR DESCRIPTION
fixes #2942 