### PR TITLE
fix (WP 6.4): render block list in nav panel only if it is open

### DIFF
--- a/src/block-components/navigation-view/edit.js
+++ b/src/block-components/navigation-view/edit.js
@@ -99,7 +99,7 @@ export const Edit = props => {
 					onToggle={ () => dispatch( 'stackable/navigation-view' ).updateIsOpen( ! isOpen ) }
 				>
 					<div className="stk-panel--navigation-view__wrapper">
-						<ListView
+						{ isOpen && <ListView
 							blocks={ blocks }
 							showOnlyCurrentHierarchy
 							showAppender
@@ -107,7 +107,7 @@ export const Edit = props => {
 							showNestedBlocks
 							__experimentalFeatures
 							__experimentalPersistentListViewFeatures
-						/>
+						/> }
 					</div>
 				</PanelAdvancedSettings>
 			</ResizableBox>


### PR DESCRIPTION
fixes #2934 