### PR TITLE
fix (image block): allow richtext in image captions

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -24,7 +24,7 @@ if ( function_exists( 'sugb_fs' ) ) {
 
 defined( 'STACKABLE_SHOW_PRO_NOTICES' ) || define( 'STACKABLE_SHOW_PRO_NOTICES', true );
 defined( 'STACKABLE_BUILD' ) || define( 'STACKABLE_BUILD', 'free' );
-defined( 'STACKABLE_VERSION' ) || define( 'STACKABLE_VERSION', '3.12.5' );
+defined( 'STACKABLE_VERSION' ) || define( 'STACKABLE_VERSION', '3.12.6' );
 defined( 'STACKABLE_FILE' ) || define( 'STACKABLE_FILE', __FILE__ );
 defined( 'STACKABLE_I18N' ) || define( 'STACKABLE_I18N', 'stackable-ultimate-gutenberg-blocks' ); // Plugin slug.
 defined( 'STACKABLE_DESIGN_LIBRARY_URL' ) || define( 'STACKABLE_DESIGN_LIBRARY_URL', 'https://storage.googleapis.com/stackable-plugin-assets' ); // Design Library CDN URL

--- a/plugin.php
+++ b/plugin.php
@@ -6,7 +6,7 @@
  * Author: Gambit Technologies, Inc
  * Author URI: http://gambit.ph
  * Text Domain: stackable-ultimate-gutenberg-blocks
- * Version: 3.12.6
+ * Version: 3.12.7
  *
  * @package Stackable
  */
@@ -24,7 +24,7 @@ if ( function_exists( 'sugb_fs' ) ) {
 
 defined( 'STACKABLE_SHOW_PRO_NOTICES' ) || define( 'STACKABLE_SHOW_PRO_NOTICES', true );
 defined( 'STACKABLE_BUILD' ) || define( 'STACKABLE_BUILD', 'free' );
-defined( 'STACKABLE_VERSION' ) || define( 'STACKABLE_VERSION', '3.12.6' );
+defined( 'STACKABLE_VERSION' ) || define( 'STACKABLE_VERSION', '3.12.7' );
 defined( 'STACKABLE_FILE' ) || define( 'STACKABLE_FILE', __FILE__ );
 defined( 'STACKABLE_I18N' ) || define( 'STACKABLE_I18N', 'stackable-ultimate-gutenberg-blocks' ); // Plugin slug.
 defined( 'STACKABLE_DESIGN_LIBRARY_URL' ) || define( 'STACKABLE_DESIGN_LIBRARY_URL', 'https://storage.googleapis.com/stackable-plugin-assets' ); // Design Library CDN URL

--- a/src/block-components/image/image.js
+++ b/src/block-components/image/image.js
@@ -457,9 +457,9 @@ const ImageContent = props => {
 	const Wrapper = props.customWrapper
 
 	const ConditionalWrapper = ( {
-		condition, wrapper, children,
+		condition, children,
 	} ) =>
-		condition ? wrapper( children ) : children
+		condition ? ( <Wrapper>{ children }</Wrapper> ) : children
 
 	let image = (
 		<img // eslint-disable-line jsx-a11y/alt-text
@@ -482,7 +482,6 @@ const ImageContent = props => {
 			( <figure className={ props.hasWrapper ? undefined : imageWrapperClasses }>
 				<ConditionalWrapper
 					condition={ !! props.customWrapper }
-					wrapper={ children => <Wrapper>{ children }</Wrapper> }
 					children={ image }
 				/>
 				{ props.figcaptionShow && props.src && <RichText.Content tagName="figcaption" className={ figcaptionClassnames } value={ props.figcaption } /> }

--- a/src/block-components/image/image.js
+++ b/src/block-components/image/image.js
@@ -456,16 +456,19 @@ const ImageContent = props => {
 	// link.
 	const Wrapper = props.customWrapper
 
+	const ConditionalWrapper = ( {
+		condition, wrapper, children,
+	} ) =>
+		condition ? wrapper( children ) : children
+
 	let image = (
-		<Wrapper>
-			<img // eslint-disable-line jsx-a11y/alt-text
-				className={ imageClasses }
-				src={ props.src || undefined }
-				width={ width || undefined }
-				height={ height || undefined }
-				{ ...propsToPass }
-			/>
-		</Wrapper>
+		<img // eslint-disable-line jsx-a11y/alt-text
+			className={ imageClasses }
+			src={ props.src || undefined }
+			width={ width || undefined }
+			height={ height || undefined }
+			{ ...propsToPass }
+		/>
 	)
 
 	image = ! props.hasWrapper ? image : (
@@ -477,10 +480,14 @@ const ImageContent = props => {
 	return (
 		applyFilters( 'stackable.image.save.wrapper',
 			( <figure className={ props.hasWrapper ? undefined : imageWrapperClasses }>
-				{ image }
+				<ConditionalWrapper
+					condition={ !! props.customWrapper }
+					wrapper={ children => <Wrapper>{ children }</Wrapper> }
+					children={ image }
+				/>
 				{ props.figcaptionShow && props.src && <RichText.Content tagName="figcaption" className={ figcaptionClassnames } value={ props.figcaption } /> }
 				{ props.children }
-			</figure> ), props, imageWrapperClasses, image
+			</figure> ), props, imageWrapperClasses, image, figcaptionClassnames
 		)
 	)
 }

--- a/src/block-components/image/image.js
+++ b/src/block-components/image/image.js
@@ -454,16 +454,18 @@ const ImageContent = props => {
 
 	// Allow a custom wrapper, mostly used to turn the image into an anchor
 	// link.
-	const Wrapper = props.customWrapper || 'figure'
+	const Wrapper = props.customWrapper
 
 	let image = (
-		<img // eslint-disable-line jsx-a11y/alt-text
-			className={ imageClasses }
-			src={ props.src || undefined }
-			width={ width || undefined }
-			height={ height || undefined }
-			{ ...propsToPass }
-		/>
+		<Wrapper>
+			<img // eslint-disable-line jsx-a11y/alt-text
+				className={ imageClasses }
+				src={ props.src || undefined }
+				width={ width || undefined }
+				height={ height || undefined }
+				{ ...propsToPass }
+			/>
+		</Wrapper>
 	)
 
 	image = ! props.hasWrapper ? image : (
@@ -474,11 +476,11 @@ const ImageContent = props => {
 
 	return (
 		applyFilters( 'stackable.image.save.wrapper',
-			( <Wrapper className={ props.hasWrapper ? undefined : imageWrapperClasses }>
+			( <figure className={ props.hasWrapper ? undefined : imageWrapperClasses }>
 				{ image }
 				{ props.figcaptionShow && props.src && <RichText.Content tagName="figcaption" className={ figcaptionClassnames } value={ props.figcaption } /> }
 				{ props.children }
-			</Wrapper> ), props, imageWrapperClasses, image
+			</figure> ), props, imageWrapperClasses, image
 		)
 	)
 }

--- a/src/block-components/image/image.js
+++ b/src/block-components/image/image.js
@@ -472,9 +472,9 @@ const ImageContent = props => {
 	)
 
 	image = ! props.hasWrapper ? image : (
-		<div className={ imageWrapperClasses }>
+		<span className={ imageWrapperClasses }>
 			{ image }
-		</div>
+		</span>
 	)
 
 	return (

--- a/src/block-components/image/image.js
+++ b/src/block-components/image/image.js
@@ -16,7 +16,9 @@ import { ResizerTooltip } from '~stackable/components'
 /**
  * WordPress dependencies
  */
-import { MediaUpload, useBlockEditContext } from '@wordpress/block-editor'
+import {
+	MediaUpload, RichText, useBlockEditContext,
+} from '@wordpress/block-editor'
 import {
 	Button, Dashicon, ResizableBox,
 } from '@wordpress/components'
@@ -474,7 +476,7 @@ const ImageContent = props => {
 		applyFilters( 'stackable.image.save.wrapper',
 			( <Wrapper className={ props.hasWrapper ? undefined : imageWrapperClasses }>
 				{ image }
-				{ props.figcaptionShow && props.src && <figcaption className={ figcaptionClassnames }>{ props.figcaption }</figcaption> }
+				{ props.figcaptionShow && props.src && <RichText.Content tagName="figcaption" className={ figcaptionClassnames } value={ props.figcaption } /> }
 				{ props.children }
 			</Wrapper> ), props, imageWrapperClasses, image
 		)

--- a/src/block-components/link/attributes.js
+++ b/src/block-components/link/attributes.js
@@ -3,7 +3,7 @@ import { addLinkAttributes } from '../helpers/link'
 export const addAttributes = ( attrObject, options = {} ) => {
 	const {
 		attrNameTemplate = 'link%s',
-		selector = 'a',
+		selector = 'a.stk-link',
 	} = options
 
 	addLinkAttributes( attrObject, attrNameTemplate, selector )

--- a/src/block-components/link/attributes.js
+++ b/src/block-components/link/attributes.js
@@ -3,7 +3,7 @@ import { addLinkAttributes } from '../helpers/link'
 export const addAttributes = ( attrObject, options = {} ) => {
 	const {
 		attrNameTemplate = 'link%s',
-		selector = 'a.stk-link',
+		selector = 'a',
 	} = options
 
 	addLinkAttributes( attrObject, attrNameTemplate, selector )

--- a/src/block/image/deprecated.js
+++ b/src/block/image/deprecated.js
@@ -19,7 +19,7 @@ addFilter( 'stackable.image.save.wrapper', 'stackable/image-link-wrapper', ( out
 	}
 
 	// Get the children of wrapped img
-	if ( semverCompare( props.version, '<', '3.12.3' ) ) {
+	if ( semverCompare( props.version, '<', '3.12.7' ) ) {
 		const Wrapper = props.customWrapper
 		return (
 			<Wrapper>
@@ -55,8 +55,8 @@ addFilter( 'stackable.image.save.wrapper', 'stackable/image-caption-wrapper', ( 
 
 const deprecated = [
 	{
-		attributes: attributes( '3.12.5' ),
-		save: withVersion( '3.12.5' )( Save ),
+		attributes: attributes( '3.12.6' ),
+		save: withVersion( '3.12.6' )( Save ),
 	},
 	{
 		attributes: attributes( '3.11.9' ),

--- a/src/block/image/deprecated.js
+++ b/src/block/image/deprecated.js
@@ -20,15 +20,17 @@ addFilter( 'stackable.image.save.wrapper', 'stackable/image-link-wrapper', ( out
 	}
 
 	// Get the children of wrapped img
-	if ( semverCompare( props.version, '<', '3.12.7' ) ) {
-		const Wrapper = props.customWrapper
+	if ( semverCompare( props.version, '<', '3.12.7' ) || semverCompare( props.version, '>', '3.12.3' ) ) {
+		const Wrapper = props.customWrapper || <figure />
 		return (
 			<Wrapper>
-				{ image }
+				<div className={ imageWrapperClasses }>
+					{ image }
+				</div>
 				{ props.figcaptionShow && props.src && <RichText.Content tagName="figcaption" className={ figcaptionClassnames } value={ props.figcaption } /> }
 				{ props.children }
 			</Wrapper>
-		 )
+		)
 	}
 
 	return output

--- a/src/block/image/deprecated.js
+++ b/src/block/image/deprecated.js
@@ -6,10 +6,11 @@ import {
 	deprecateBlockBackgroundColorOpacity, deprecateContainerBackgroundColorOpacity, deprecationImageOverlayOpacity,
 } from '~stackable/block-components'
 
+import { RichText } from '@wordpress/block-editor'
 import { addFilter } from '@wordpress/hooks'
 import { semverCompare } from '~stackable/util'
 
-addFilter( 'stackable.image.save.wrapper', 'stackable/image-link-wrapper', ( output, props, imageWrapperClasses, image ) => {
+addFilter( 'stackable.image.save.wrapper', 'stackable/image-link-wrapper', ( output, props, imageWrapperClasses, image, figcaptionClassnames ) => {
 	if ( ! props.version ) {
 		return output
 	}
@@ -24,6 +25,8 @@ addFilter( 'stackable.image.save.wrapper', 'stackable/image-link-wrapper', ( out
 		return (
 			<Wrapper>
 				{ image }
+				{ props.figcaptionShow && props.src && <RichText.Content tagName="figcaption" className={ figcaptionClassnames } value={ props.figcaption } /> }
+				{ props.children }
 			</Wrapper>
 		 )
 	}

--- a/src/block/image/deprecated.js
+++ b/src/block/image/deprecated.js
@@ -9,6 +9,28 @@ import {
 import { addFilter } from '@wordpress/hooks'
 import { semverCompare } from '~stackable/util'
 
+addFilter( 'stackable.image.save.wrapper', 'stackable/image-link-wrapper', ( output, props, imageWrapperClasses, image ) => {
+	if ( ! props.version ) {
+		return output
+	}
+
+	if ( ! props.hasWrapper ) { // Image block is the only one with a wrapper
+		return output
+	}
+
+	// Get the children of wrapped img
+	if ( semverCompare( props.version, '<', '3.12.3' ) ) {
+		const Wrapper = props.customWrapper
+		return (
+			<Wrapper>
+				{ image }
+			</Wrapper>
+		 )
+	}
+
+	return output
+} )
+
 addFilter( 'stackable.image.save.wrapper', 'stackable/image-caption-wrapper', ( output, props, imageWrapperClasses, image ) => {
 	if ( ! props.version ) {
 		return output
@@ -28,19 +50,14 @@ addFilter( 'stackable.image.save.wrapper', 'stackable/image-caption-wrapper', ( 
 		 )
 	}
 
-	if ( semverCompare( props.version, '<', '3.12.6' ) ) {
-		const Wrapper = props.customWrapper
-		return (
-			<Wrapper>
-				{ image }
-			</Wrapper>
-		)
-	}
-
 	return output
 } )
 
 const deprecated = [
+	{
+		attributes: attributes( '3.12.5' ),
+		save: withVersion( '3.12.5' )( Save ),
+	},
 	{
 		attributes: attributes( '3.11.9' ),
 		save: withVersion( '3.11.9' )( Save ),

--- a/src/block/image/deprecated.js
+++ b/src/block/image/deprecated.js
@@ -28,6 +28,15 @@ addFilter( 'stackable.image.save.wrapper', 'stackable/image-caption-wrapper', ( 
 		 )
 	}
 
+	if ( semverCompare( props.version, '<', '3.12.6' ) ) {
+		const Wrapper = props.customWrapper
+		return (
+			<Wrapper>
+				{ image }
+			</Wrapper>
+		)
+	}
+
 	return output
 } )
 

--- a/src/block/image/deprecated.js
+++ b/src/block/image/deprecated.js
@@ -19,13 +19,12 @@ addFilter( 'stackable.image.save.wrapper', 'stackable/image-link-wrapper', ( out
 		return output
 	}
 
-	// Get the children of wrapped img
-	if ( semverCompare( props.version, '<', '3.12.7' ) || semverCompare( props.version, '>', '3.12.3' ) ) {
-		const Wrapper = props.customWrapper || <figure />
+	if ( semverCompare( props.version, '<', '3.12.7' ) ) {
+		const Wrapper = props.customWrapper || 'figure'
 		return (
 			<Wrapper>
 				<div className={ imageWrapperClasses }>
-					{ image }
+					{ image.props.children }
 				</div>
 				{ props.figcaptionShow && props.src && <RichText.Content tagName="figcaption" className={ figcaptionClassnames } value={ props.figcaption } /> }
 				{ props.children }
@@ -46,7 +45,7 @@ addFilter( 'stackable.image.save.wrapper', 'stackable/image-caption-wrapper', ( 
 	}
 
 	// Get the children of wrapped img
-	if ( semverCompare( props.version, '<', '3.12.3' ) ) {
+	if ( semverCompare( props.version, '<', '3.12.4' ) ) {
 		const Wrapper = props.customWrapper || 'figure'
 		return (
 			<Wrapper className={ imageWrapperClasses }>
@@ -62,6 +61,10 @@ const deprecated = [
 	{
 		attributes: attributes( '3.12.6' ),
 		save: withVersion( '3.12.6' )( Save ),
+	},
+	{
+		attributes: attributes( '3.12.3' ),
+		save: withVersion( '3.12.3' )( Save ),
 	},
 	{
 		attributes: attributes( '3.11.9' ),

--- a/src/block/image/schema.js
+++ b/src/block/image/schema.js
@@ -23,7 +23,7 @@ export const attributes = ( version = VERSION ) => {
 	BlockDiv.addAttributes( attrObject )
 	Style.addAttributes( attrObject )
 	Image.addAttributes( attrObject )
-	Link.addAttributes( attrObject )
+	Link.addAttributes( attrObject, { selector: 'a.stk-link' } )
 	Alignment.addAttributes( attrObject )
 	Advanced.addAttributes( attrObject )
 	Transform.addAttributes( attrObject )


### PR DESCRIPTION
fixes #2964 

# TODO

This is an incomplete fix. Now that RichText in the image caption is allowed, it now conflicts with the image link: If you add an image block, then add a caption with a link, then also add a link from the advanced tab > link, the block will produce an error after saving and refreshing the editor.

The cause of the error is that the Adv tab > Link option incorrectly changes the `figure` tag into an `a` tag. The browser then detects that there is an `a` tag within an `a` tag (because you have a link in the figcaption), and tries to split the 2 `a` tags and that messes up the block structure causing the block error.

The proposed fix for this is to change the implementation of `customWrapper` in `src/block-components/image/image.js`. Since this prop is only used to turn the image into the link, we need to change this into `linkUrl` prop instead.. the image should **always** be a `figure`, then if the image needs to be made into a link, then it should just wrap the `img` tag with a link.