### PR TITLE
fix (column-width): changed responsive media queries

### DIFF
--- a/src/block-components/column/style.js
+++ b/src/block-components/column/style.js
@@ -73,7 +73,7 @@ const ColumnStyles = props => {
 				styleRule="flex"
 				attrName="columnWidth"
 				key="columnWidth-save-flex"
-				responsive={ [ 'desktopTablet', 'tabletOnly', 'mobile' ] }
+				responsive={ [ 'desktopOnly', 'tabletOnly', 'mobile' ] }
 				format="1 1 %s%"
 				dependencies={ [
 					'columnAdjacentCount',


### PR DESCRIPTION
Reference: https://www.notion.so/Tablet-column-width-is-not-followed-if-1024px-is-mobile-breakpoint-7ff8f22c67a844b1a3355459f40088ed?pvs=4