### PR TITLE
feat (columns): allow column wrapping in desktop

### DIFF
--- a/src/block-components/column/attributes.js
+++ b/src/block-components/column/attributes.js
@@ -12,6 +12,10 @@ export const addAttributes = attrObject => {
 				type: 'number',
 				default: '',
 			},
+			columnWrapDesktop: {
+				type: 'boolean',
+				default: false,
+			},
 		},
 		versionAdded: '3.0.0',
 		versionDeprecated: '',

--- a/src/block-components/column/style.js
+++ b/src/block-components/column/style.js
@@ -89,7 +89,7 @@ const ColumnStyles = props => {
 					// 30% columns in tablet/mobile, they will expand to 50% 50%)
 					//
 					// No need to do this in the editor since it already does this.
-					const value = device === 'desktop' ? _value : _value.replace( /^1 1/, '0 1' )
+					const value = device === 'desktop' && ! getAttribute( 'columnWrapDesktop' ) ? _value : _value.replace( /^1 1/, '0 1' )
 
 					const adjacentCount = getAttribute( 'columnAdjacentCount', device )
 					if ( adjacentCount ) {

--- a/src/block-components/column/use-column.js
+++ b/src/block-components/column/use-column.js
@@ -21,12 +21,40 @@ export const useColumn = () => {
 				results[ 1 ][ clientId ] = {
 					columnWidth: width,
 					columnAdjacentCount: widths.length,
+					columnWrapDesktop: false,
 				}
 				return results
 			}, [ [], {} ] )
 
 			dispatch( 'core/block-editor' ).updateBlockAttributes( clientIds, attributes, true ) // eslint-disable-line stackable/no-update-block-attributes
 		}
+	}
+
+	const onChangeDesktopWrap = ( width, widths ) => {
+		const clientIds = [ clientId ]
+		const attributes = {
+			[ clientId ]: { columnWidth: width },
+		}
+
+		const { parentBlock } = select( 'stackable/block-context' ).getBlockContext( clientId )
+		const adjacentBlocks = parentBlock?.innerBlocks || []
+
+		if ( adjacentBlocks.length ) {
+			const columnRows = getRowsFromColumns( widths )
+
+			// Update multiple blocks.
+			widths.forEach( ( width, i ) => {
+				const clientId = adjacentBlocks[ i ].clientId
+				clientIds.push( clientId )
+				attributes[ clientId ] = {
+					columnWidth: width,
+					columnAdjacentCount: columnRows.filter( n => n === columnRows[ i ] ).length,
+					columnWrapDesktop: true,
+				}
+			} )
+		}
+
+		dispatch( 'core/block-editor' ).updateBlockAttributes( clientIds, attributes, true ) // eslint-disable-line stackable/no-update-block-attributes
 	}
 
 	const onChangeTablet = ( width, widths ) => {
@@ -103,6 +131,7 @@ export const useColumn = () => {
 
 	return {
 		onChangeDesktop,
+		onChangeDesktopWrap,
 		onChangeTablet,
 		onChangeMobile,
 		onResetDesktop,

--- a/src/block-components/columns/attributes.js
+++ b/src/block-components/columns/attributes.js
@@ -17,6 +17,10 @@ export const addAttributes = attrObject => {
 				type: 'number',
 				default: '',
 			},
+			columnWrapDesktop: { // Only applies to desktops
+				type: 'boolean',
+				default: false,
+			},
 		},
 		versionAdded: '3.0.0',
 		versionDeprecated: '',

--- a/src/block-components/columns/edit.js
+++ b/src/block-components/columns/edit.js
@@ -10,6 +10,7 @@ import { getRowsFromColumns } from '../column/util'
 import { i18n } from 'stackable'
 import {
 	AdvancedRangeControl,
+	AdvancedToggleControl,
 	ColumnsWidthControl,
 	ColumnsWidthMultiControl,
 	ControlSeparator,
@@ -39,6 +40,7 @@ export const Controls = props => {
 		return {
 			columnArrangementTablet: attributes.columnArrangementTablet,
 			columnArrangementMobile: attributes.columnArrangementMobile,
+			columnWrapDesktop: attributes.columnWrapDesktop,
 		}
 	} )
 	const setAttributes = useBlockSetAttributesContext()
@@ -71,7 +73,13 @@ export const Controls = props => {
 	return (
 		<>
 			{ props.hasColumnsControl && <ColumnsControl /> }
-			{ numInnerBlocks > 1 && deviceType !== 'Tablet' && deviceType !== 'Mobile' &&
+			{ numInnerBlocks > 1 && deviceType === 'Desktop' &&
+				<AdvancedToggleControl
+					label={ __( 'Allow Column Wrapping', i18n ) }
+					attribute="columnWrapDesktop"
+				/>
+			}
+			{ numInnerBlocks > 1 && deviceType !== 'Tablet' && deviceType !== 'Mobile' && ! attributes.columnWrapDesktop &&
 				<ColumnsWidthControl
 					columns={ numInnerBlocks }
 					values={ columnWidths }
@@ -95,14 +103,16 @@ export const Controls = props => {
 					} }
 				/>
 			}
-			{ numInnerBlocks > 1 && ( deviceType === 'Tablet' || deviceType === 'Mobile' ) &&
+			{ numInnerBlocks > 1 && ( deviceType === 'Tablet' || deviceType === 'Mobile' || attributes.columnWrapDesktop ) &&
 				<ColumnsWidthMultiControl
 					columns={ numInnerBlocks }
-					values={ deviceType === 'Tablet' ? columnWidthsTablet : columnWidthsMobile }
+					values={ deviceType === 'Desktop' ? columnWidths
+						: deviceType === 'Tablet' ? columnWidthsTablet
+						 : columnWidthsMobile }
 					responsive="all"
 					hasTabletValue={ hasTabletColumnWidths }
 					hasMobileValue={ hasMobileColumnWidths }
-					placeholders={ deviceType === 'Tablet' ? columnWidths : Array( numInnerBlocks ).fill( '100' ) }
+					placeholders={ deviceType === 'Mobile' ? Array( numInnerBlocks ).fill( '100' ) : columnWidths }
 					allowReset={ true }
 					onChange={ columnWidths => {
 						const columnRows = getRowsFromColumns( columnWidths )

--- a/src/block-components/columns/style.js
+++ b/src/block-components/columns/style.js
@@ -57,6 +57,24 @@ const Styles = props => {
 				format="%spx"
 				responsive="all"
 			/>
+			<BlockCss
+				{ ...propsToPass }
+				renderIn="save"
+				selector=".%s-column"
+				styleRule="flexWrap"
+				attrName="columnWrapDesktop"
+				key="columnWrapDesktop-save"
+				valueCallback={ value => value ? 'wrap' : undefined }
+			/>
+			<BlockCss
+				{ ...propsToPass }
+				renderIn="edit"
+				selector=".%s-column > .block-editor-inner-blocks > .block-editor-block-list__layout"
+				styleRule="flexWrap"
+				attrName="columnWrapDesktop"
+				key="columnWrapDesktop"
+				valueCallback={ value => value ? 'wrap' : undefined }
+			/>
 			{ hasRowGap && <>
 				<BlockCss
 					{ ...propsToPass }

--- a/src/block/column/block.json
+++ b/src/block/column/block.json
@@ -4,7 +4,7 @@
 	"title": "Inner Column",
 	"description": "A single column with advanced layout options.",
 	"category": "stackable",
-	"usesContext": [ "postId", "postType", "queryId", "stackable/innerBlockOrientation" ],
+	"usesContext": [ "postId", "postType", "queryId", "stackable/innerBlockOrientation", "stackable/columnWrapDesktop" ],
 	"providesContext": {
 		"stackable/innerBlockOrientation": "innerBlockOrientation"
 	},

--- a/src/block/columns/block.json
+++ b/src/block/columns/block.json
@@ -14,7 +14,8 @@
 		"Container"
 	],
 	"providesContext": {
-		"stackable/innerBlockOrientation": "columnJustify"
+		"stackable/innerBlockOrientation": "columnJustify",
+		"stackable/columnWrapDesktop": "columnWrapDesktop"
 	},
 	"textdomain": "stackable-ultimate-gutenberg-blocks",
 	"stk-type": "essential",

--- a/src/block/feature-grid/block.json
+++ b/src/block/feature-grid/block.json
@@ -5,6 +5,9 @@
 	"description": "Display multiple product features or services. You can use Feature Grids one after another.",
 	"category": "stackable",
 	"usesContext": [ "postId", "postType", "queryId" , "stackable/innerBlockOrientation" ],
+	"providesContext": {
+		"stackable/columnWrapDesktop": "columnWrapDesktop"
+	},
 	"textdomain": "stackable-ultimate-gutenberg-blocks",
 	"stk-type": "section",
 	"stk-demo": "https://wpstackable.com/feature-grid-block/?utm_source=welcome&utm_medium=settings&utm_campaign=view_demo&utm_content=demolink"

--- a/src/block/feature/block.json
+++ b/src/block/feature/block.json
@@ -5,6 +5,9 @@
 	"description": "Display a product feature or a service in a large area.",
 	"category": "stackable",
 	"usesContext": [ "postId", "postType", "queryId" , "stackable/innerBlockOrientation" ],
+	"providesContext": {
+		"stackable/columnWrapDesktop": "columnWrapDesktop"
+	},
 	"textdomain": "stackable-ultimate-gutenberg-blocks",
 	"stk-type": "section",
 	"stk-demo": "https://wpstackable.com/feature-block/?utm_source=welcome&utm_medium=settings&utm_campaign=view_demo&utm_content=demolink"

--- a/src/components/resizable-column/index.js
+++ b/src/components/resizable-column/index.js
@@ -54,6 +54,7 @@ const ResizableColumn = props => {
 
 	// Block context is provided from the parent Columns block.
 	const allowResize = ! props.context[ 'stackable/innerBlockOrientation' ]
+	const columnWrapDesktop = !! props.context[ 'stackable/columnWrapDesktop' ]
 
 	// This is used to add editor classes based on the preview device type.
 	// Mainly for generating editor styles.
@@ -94,6 +95,12 @@ const ResizableColumn = props => {
 		}
 	}, [ adjacentBlocks ] )
 
+	useEffect( () => {
+		if ( ! columnWrapDesktop ) {
+			props.onResetDesktop()
+		}
+	}, [ columnWrapDesktop ] )
+
 	// We have a timeout below, this ensures that our timeout only runs while
 	// this Component is mounted.
 	const [ isMounted, setIsMounted ] = useState( false )
@@ -116,9 +123,9 @@ const ResizableColumn = props => {
 
 	const enable = {
 		top: false,
-		right: deviceType === 'Desktop' ? ! isOnlyBlock && ! isLastBlock : ! isOnlyBlock,
+		right: deviceType === 'Desktop' ? ! isOnlyBlock && ( ! isLastBlock || columnWrapDesktop ) : ! isOnlyBlock,
 		bottom: false,
-		left: deviceType === 'Desktop' ? ! isOnlyBlock && ! isFirstBlock : false,
+		left: deviceType === 'Desktop' ? ! isOnlyBlock && ! isFirstBlock && ! columnWrapDesktop : false,
 		topRight: false,
 		bottomRight: false,
 		bottomLeft: false,
@@ -147,7 +154,7 @@ const ResizableColumn = props => {
 		const adjacentBlocks = _adjacentBlocks.current = parentBlock.innerBlocks
 
 		// In desktop, get all the column widths.
-		if ( isDesktop ) {
+		if ( isDesktop && ! columnWrapDesktop ) {
 			// In desktop, the column gaps will affect the width of the parent column, take it into account.
 			const totalColumnGap = parentColumnGaps.desktop * ( adjacentBlocks.length - 1 )
 
@@ -203,7 +210,7 @@ const ResizableColumn = props => {
 		const adjacentBlocks = _adjacentBlocks.current
 
 		// In desktop, when one column is resized, the next column is adjusted also.
-		if ( isDesktop ) {
+		if ( isDesktop && ! columnWrapDesktop ) {
 			// Compute for the new widths.
 			const columnWidths = [ ...currentWidths ]
 			const totalWidth = currentWidths.reduce( ( a, b ) => a + b, 0 )
@@ -292,7 +299,7 @@ const ResizableColumn = props => {
 
 		// Update the block widths.
 		if ( delta.width ) {
-			if ( isDesktop ) {
+			if ( isDesktop && ! columnWrapDesktop ) {
 				// For even 3-columns, floats have a tendency of being
 				// unequal, e.g. 33.35 or 33.43, assume to be equal.
 				if ( isEqual( newWidthsPercent.map( n => n | 0 ), [ 33, 33, 33 ] ) ) { // eslint-disable-line no-bitwise
@@ -300,6 +307,13 @@ const ResizableColumn = props => {
 				} else {
 					props.onChangeDesktop( newWidthsPercent )
 				}
+			} else if ( isDesktop ) {
+				const columnWidths = adjacentBlocks.map( ( { attributes } ) => {
+					return attributes.columnWidth || 100 / adjacentBlocks.length
+				} )
+				columnWidths[ blockIndex ] = newWidthsPercent
+
+				props.onChangeDesktopWrap( newWidthsPercent, columnWidths, blockIndex )
 			} else if ( isTablet ) {
 				// Get the current column widths for tablet.
 				const columnWidths = adjacentBlocks.map( ( { attributes } ) => {
@@ -342,7 +356,7 @@ const ResizableColumn = props => {
 		const adjacentBlocks = parentBlock.innerBlocks
 
 		// For desktop, column adjustments also affect the adjacent column.
-		if ( isDesktop ) {
+		if ( isDesktop && ! columnWrapDesktop ) {
 			// Get the current column widths.
 			const isFirstResize = adjacentBlocks.every( ( { attributes } ) => ! attributes.columnWidth )
 			const columnWidths = adjacentBlocks.map( ( { attributes } ) => {
@@ -365,6 +379,17 @@ const ResizableColumn = props => {
 			columnWidths[ blockIndex ] = finalWidth
 
 			props.onChangeDesktop( columnWidths )
+		} else if ( isDesktop ) {
+			// Get the current column widths.
+			const columnWidths = adjacentBlocks.map( ( { attributes } ) => {
+				return attributes.columnWidth || 100 / adjacentBlocks.length
+			} )
+
+			const finalWidth = width ? clamp( width, MIN_COLUMN_WIDTH_PERCENTAGE[ deviceType ], 100 ) : ''
+
+			columnWidths[ blockIndex ] = finalWidth
+
+			props.onChangeDesktopWrap( finalWidth, columnWidths, blockIndex )
 		} else if ( isTablet ) {
 			// Get the current column widths.
 			const columnWidths = adjacentBlocks.map( ( { attributes } ) => {

--- a/src/components/resizable-column/index.js
+++ b/src/components/resizable-column/index.js
@@ -96,8 +96,9 @@ const ResizableColumn = props => {
 	}, [ adjacentBlocks ] )
 
 	useEffect( () => {
-		if ( ! columnWrapDesktop ) {
-			props.onResetDesktop()
+		// const total = newWidthsPercent.reduce( ( a, b ) => a + b, 0 )
+		if ( isDesktop && ! columnWrapDesktop ) {
+			fixWidthOnDisableWrap()
 		}
 	}, [ columnWrapDesktop ] )
 
@@ -414,6 +415,29 @@ const ResizableColumn = props => {
 			columnWidths[ blockIndex ] = finalWidth
 
 			props.onChangeMobile( finalWidth, columnWidths, blockIndex )
+		}
+	}
+
+	const fixWidthOnDisableWrap = () => {
+		const parentBlock = select( 'core/block-editor' ).getBlock( parentBlockClientId )
+		const adjacentBlocks = _adjacentBlocks.current = parentBlock.innerBlocks
+
+		let totalPercentages = 0
+		const columnPercentages = adjacentBlocks.map( ( { attributes } ) => {
+			totalPercentages += attributes.columnWidth
+			return attributes.columnWidth
+		} )
+
+		// Update the last column width to make it 100%
+		// if the columnWidth of adjacent blocks is set and the total percentage is less than 100
+		if ( totalPercentages < 100 && totalPercentages > 0 ) {
+			columnPercentages[ columnPercentages.length - 1 ] += ( 100 - totalPercentages )
+
+			if ( isEqual( columnPercentages.map( n => n | 0 ), [ 33, 33, 33 ] ) ) { // eslint-disable-line no-bitwise
+				props.onChangeDesktop( [ 33.33, 33.33, 33.33 ] )
+			} else {
+				props.onChangeDesktop( columnPercentages )
+			}
 		}
 	}
 


### PR DESCRIPTION
Added a new option called **Allow Column Wrapping** in columns: 
![image](https://github.com/gambitph/Stackable/assets/1033611/b1221459-e58a-4196-ba2f-5480f8b2a0c5)

Enabling it will change the column width controls to allow the columns to wrap below one another similar to how columns work in tablet & mobile.

We added a new attribute `columnWrapDesktop` for the columns block to allow wrapping in desktops.

#### TODO

- [ ] When Allow Column Wrapping is enabled, the column resizers should behave similar to how the resizers work in tablet & mobile (they shouldn't auto-compute to 100% total column widths) - check the ResizableColumn component
- [ ] Unsure: When changing individual columns, if you do not supply a value, the widths look broken - we do not need to really handle this scenario since we cannot assume what the user is trying to do, but maybe there's a way not to make it look broken e.g.
  - 3 columns: 50%, 50%, blank 
<img width="1340" alt="image" src="https://github.com/gambitph/Stackable/assets/1033611/50f26c55-d300-4c38-be31-9286cc6681ce">
  - 3 columns: blank, 50%, 50% 
<img width="1325" alt="image" src="https://github.com/gambitph/Stackable/assets/1033611/0b1f56bc-0dcb-4b42-8ad5-4012777c69a4">
