### PR TITLE
fix (tabs): prevent block and button border radius from being sustained when changing tab label styles

### DIFF
--- a/src/block/tab-labels/block-styles.js
+++ b/src/block/tab-labels/block-styles.js
@@ -71,6 +71,18 @@ const ATTRIBUTES_TO_CLEAR = {
 	activeTabIconColor1: '',
 	tabIconColor1Hover: '',
 	activeTabIconColor1Hover: '',
+	tabBorderRadius2: {
+		top: '',
+		right: '',
+		bottom: '',
+		left: '',
+	},
+	blockBorderRadius2: {
+		top: '',
+		right: '',
+		bottom: '',
+		left: '',
+	},
 }
 
 export const blockStyles = [


### PR DESCRIPTION
fixes #3066 