### PR TITLE
Fixed WordPress minimum required version number to 6.2 in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -234,7 +234,7 @@ Add animations that will bring your site to life and make it more visually engag
 
 = Minimum Requirements =
 
-You'll need WordPress version 6.1 or higher for this to work.
+You'll need WordPress version 6.2 or higher for this to work.
 
 == Frequently Asked Questions ==
 


### PR DESCRIPTION
Hello @bfintal

Fixed WordPress minimum required version number to 6.2 in readme.txt

Thanks.

P.S. Please also take a look at these PRs of mine ( #2821 and #2868 )