### PR TITLE
fix: update alignment polyfill for Firefox

### DIFF
--- a/src/block-components/alignment/edit.js
+++ b/src/block-components/alignment/edit.js
@@ -13,7 +13,6 @@ import {
 	useBlockAttributesContext,
 	useBlockSetAttributesContext,
 	useDeviceType,
-	useBlockContext,
 } from '~stackable/hooks'
 
 /**
@@ -22,6 +21,7 @@ import {
 import {
 	AlignmentToolbar,
 	BlockControls,
+	useBlockEditContext,
 } from '@wordpress/block-editor'
 import { Fragment } from '@wordpress/element'
 import { sprintf, __ } from '@wordpress/i18n'
@@ -357,12 +357,12 @@ export const Edit = props => {
 const userAgent = navigator?.userAgent
 if ( userAgent && userAgent.indexOf( 'Firefox' ) !== -1 ) {
 	addFilter( 'stackable.block-components.block-div.classnames', 'alignment-editor-has-polyfill', classes => {
-		const {
-			hasInnerBlocks, numInnerBlocks, innerBlocks,
-		} = useBlockContext()
+		// use WP's block edit context since our useBlockContext might still be updating when a block is removed
+		const blockProps = useBlockEditContext()
+		const { innerBlocks } = select( 'core/block-editor' ).getBlock( blockProps.clientId )
 
-		if ( hasInnerBlocks ) {
-			for ( let i = 0; i < numInnerBlocks; i++ ) {
+		if ( innerBlocks.length > 0 ) {
+			for ( let i = 0; i < innerBlocks.length; i++ ) {
 				const innerBlockClientId = innerBlocks[ i ].clientId
 				const { blockMargin } = select( 'core/block-editor' ).getBlockAttributes( innerBlockClientId )
 				if ( blockMargin && ( blockMargin.top === 'auto' || blockMargin.bottom === 'auto' ) ) {


### PR DESCRIPTION
fixes #3148 

error is happening because blockContext is not yet updated and we're trying to retrieve the block attributes of a removed blocked.
<img width="1216" alt="Screenshot 2024-04-12 at 4 10 30 PM" src="https://github.com/gambitph/Stackable/assets/98727316/abfe3631-8928-4396-be7d-0e56c58f1ac0">
