### PR TITLE
fix: uploaded svg icon not showing

### DIFF
--- a/src/block/carousel/style.js
+++ b/src/block/carousel/style.js
@@ -109,6 +109,15 @@ const Styles = props => {
 			/>
 			<BlockCss
 				{ ...propsToPass }
+				selector=".stk-block-carousel__button svg.ugb-custom-icon path"
+				hoverSelector=".stk-block-carousel__button svg.ugb-custom-icon path:hover"
+				styleRule="fill"
+				attrName="arrowIconColor"
+				key="arrowIconColor"
+				hover="all"
+			/>
+			<BlockCss
+				{ ...propsToPass }
 				styleRule="--button-width"
 				attrName="arrowWidth"
 				key="arrowWidth"

--- a/src/block/carousel/style.js
+++ b/src/block/carousel/style.js
@@ -109,8 +109,8 @@ const Styles = props => {
 			/>
 			<BlockCss
 				{ ...propsToPass }
-				selector=".stk-block-carousel__button svg.ugb-custom-icon path"
-				hoverSelector=".stk-block-carousel__button svg.ugb-custom-icon path:hover"
+				selector=".stk-block-carousel__button svg.ugb-custom-icon :is(g,path,rect,polygon,ellipse)"
+				hoverSelector=".stk-block-carousel__button svg.ugb-custom-icon :is(g,path,rect,polygon,ellipse):hover"
 				styleRule="fill"
 				attrName="arrowIconColor"
 				key="arrowIconColor"

--- a/src/block/icon-list-item/style.scss
+++ b/src/block/icon-list-item/style.scss
@@ -18,7 +18,7 @@
 	}
 
 	// Apply the color to the SVG path on the defintion
-	svg.ugb-custom-icon path {
+	svg.ugb-custom-icon :is(g,path,rect,polygon,ellipse) {
 		fill: var(--stk-icon-list-marker-color) !important;
 		color: var(--stk-icon-list-marker-color) !important;
 	}

--- a/src/block/icon-list-item/style.scss
+++ b/src/block/icon-list-item/style.scss
@@ -16,6 +16,12 @@
 		border-width: 1px;
 		border-color: rgba(0, 0, 0, 0.4);
 	}
+
+	// Apply the color to the SVG path on the defintion
+	svg.ugb-custom-icon path {
+		fill: var(--stk-icon-list-marker-color);
+		color: var(--stk-icon-list-marker-color);
+	}
 }
 
 .stk-block-icon-list-item__content {

--- a/src/block/icon-list-item/style.scss
+++ b/src/block/icon-list-item/style.scss
@@ -19,8 +19,8 @@
 
 	// Apply the color to the SVG path on the defintion
 	svg.ugb-custom-icon path {
-		fill: var(--stk-icon-list-marker-color);
-		color: var(--stk-icon-list-marker-color);
+		fill: var(--stk-icon-list-marker-color) !important;
+		color: var(--stk-icon-list-marker-color) !important;
 	}
 }
 

--- a/src/block/map/deprecated.js
+++ b/src/block/map/deprecated.js
@@ -4,7 +4,7 @@ import { Save } from './save'
 import { attributes } from './schema'
 
 import { withVersion } from '~stackable/higher-order'
-import { semverCompare } from '~stackable/util'
+import { semverCompare, createElementFromHTMLString } from '~stackable/util'
 import {
 	deprecateBlockBackgroundColorOpacity, deprecateContainerBackgroundColorOpacity,
 	deprecateBlockShadowColor, deprecateContainerShadowColor,
@@ -12,9 +12,17 @@ import {
 
 import { addFilter } from '@wordpress/hooks'
 
-addFilter( 'stackable.map.util.applySVGAttributes', 'stackable/3.13.0', ( output, attribute, props ) => {
+const getIconOptions_3_13_0 = attributes => {
+	const newAttributes = { ...attributes }
+	const svgEl = createElementFromHTMLString( attributes.icon )
+	svgEl.firstElementChild.setAttribute( 'fill', 'currentColor' )
+	newAttributes.icon = svgEl.outerHTML
+	return getIconOptions( newAttributes )
+}
+
+addFilter( 'stackable.map.icon-options', 'stackable/3.13.0', ( output, attribute, props ) => {
 	if ( semverCompare( props.version, '<', '3.13.0' ) ) {
-		return getIconOptions( attribute, true )
+		return getIconOptions_3_13_0( attribute )
 	}
 	return output
 } )

--- a/src/block/map/deprecated.js
+++ b/src/block/map/deprecated.js
@@ -1,11 +1,23 @@
+import { getIconOptions } from './util'
+
 import { Save } from './save'
 import { attributes } from './schema'
 
 import { withVersion } from '~stackable/higher-order'
+import { semverCompare } from '~stackable/util'
 import {
 	deprecateBlockBackgroundColorOpacity, deprecateContainerBackgroundColorOpacity,
 	deprecateBlockShadowColor, deprecateContainerShadowColor,
 } from '~stackable/block-components'
+
+import { addFilter } from '@wordpress/hooks'
+
+addFilter( 'stackable.map.util.applySVGAttributes', 'stackable/3.13.0', ( output, attribute, props ) => {
+	if ( semverCompare( props.version, '<', '3.13.0' ) ) {
+		return getIconOptions( attribute, true )
+	}
+	return output
+} )
 
 const deprecated = [
 	{

--- a/src/block/map/save.js
+++ b/src/block/map/save.js
@@ -29,6 +29,7 @@ import { i18n, version as VERSION } from 'stackable'
 import { __ } from '@wordpress/i18n'
 import { compose } from '@wordpress/compose'
 import { RawHTML } from '@wordpress/element'
+import { applyFilters } from '@wordpress/hooks'
 
 export const Save = props => {
 	const {
@@ -90,7 +91,14 @@ export const Save = props => {
 					<div
 						data-map-options={ JSON.stringify( mapOptions ) }
 						data-marker-options={ JSON.stringify( markerOptions ) }
-						data-icon-options={ JSON.stringify( getIconOptions( attributes ) ) }
+						data-icon-options={ JSON.stringify(
+							applyFilters(
+								'stackable.map.util.applySVGAttributes',
+								getIconOptions( attributes, false ),
+								attributes,
+								props
+							)
+						) }
 						className="stk-block-map__canvas"
 					/>
 				)

--- a/src/block/map/save.js
+++ b/src/block/map/save.js
@@ -93,8 +93,8 @@ export const Save = props => {
 						data-marker-options={ JSON.stringify( markerOptions ) }
 						data-icon-options={ JSON.stringify(
 							applyFilters(
-								'stackable.map.util.applySVGAttributes',
-								getIconOptions( attributes, false ),
+								'stackable.map.icon-options',
+								getIconOptions( attributes ),
 								attributes,
 								props
 							)

--- a/src/block/map/util.js
+++ b/src/block/map/util.js
@@ -57,18 +57,21 @@ export const getIconOptions = attributes => {
 		return null
 	 }
 
-	svgEl.firstElementChild.setAttribute( 'fill', 'currentColor' )
+	// Remove this since sets the fill to the default color black, even when no color is selected.
+	// svgEl.firstElementChild.setAttribute( 'fill', 'currentColor' )
 	const svgIconSize = iconSize ? parseInt( iconSize, 10 ) : DEFAULT_ICON_SIZE
 	svgEl.setAttribute( 'height', svgIconSize )
 	svgEl.setAttribute( 'width', svgIconSize )
 	svgEl.setAttribute( 'style', `color: ${ iconColor1 || DEFAULT_ICON_COLOR }; opacity: ${ iconOpacity || iconOpacity === 0 ? parseFloat( iconOpacity, 10 ) : DEFAULT_ICON_OPACITY }` )
 	svgEl.setAttribute( 'transform', `rotate(${ iconRotation || iconRotation === 0 ? parseInt( iconRotation, 10 ) : DEFAULT_ICON_ROTATION })` )
 
-	// Apply the fill directly to the SVG shapes
-	const svgShapes = svgEl.querySelectorAll( 'g,path,rect,polygon,ellipse' )
-	svgShapes.forEach( svgShape => {
-		svgShape.setAttribute( 'style', `fill: ${ iconColor1 }` )
-	} )
+	if ( iconColor1 ) {
+		// Apply the fill directly to the SVG shapes
+		const svgShapes = svgEl.querySelectorAll( 'g,path,rect,polygon,ellipse' )
+		svgShapes.forEach( svgShape => {
+			svgShape.setAttribute( 'style', `fill: ${ iconColor1 }` )
+		} )
+	}
 
 	const serializedString = new XMLSerializer().serializeToString( svgEl ) //eslint-disable-line no-undef
 	const iconUrl = `data:image/svg+xml;base64,${ window.btoa( serializedString ) }`

--- a/src/block/map/util.js
+++ b/src/block/map/util.js
@@ -74,14 +74,6 @@ export const getIconOptions = ( attributes, isDeprecated ) => {
 	svgEl.setAttribute( 'style', `color: ${ iconColor1 || DEFAULT_ICON_COLOR }; opacity: ${ iconOpacity || iconOpacity === 0 ? parseFloat( iconOpacity, 10 ) : DEFAULT_ICON_OPACITY }` )
 	svgEl.setAttribute( 'transform', `rotate(${ iconRotation || iconRotation === 0 ? parseInt( iconRotation, 10 ) : DEFAULT_ICON_ROTATION })` )
 
-	if ( iconColor1 ) {
-		// Apply the fill directly to the SVG shapes
-		const svgShapes = svgEl.querySelectorAll( 'g,path,rect,polygon,ellipse' )
-		svgShapes.forEach( svgShape => {
-			svgShape.setAttribute( 'style', `fill: ${ iconColor1 }` )
-		} )
-	}
-
 	const serializedString = new XMLSerializer().serializeToString( svgEl ) //eslint-disable-line no-undef
 	const iconUrl = `data:image/svg+xml;base64,${ window.btoa( serializedString ) }`
 	const iconOptions = { url: iconUrl }

--- a/src/block/map/util.js
+++ b/src/block/map/util.js
@@ -38,7 +38,7 @@ export const getMapStyles = ( { mapStyle, customMapStyle } ) => {
 	return styleJSON
 }
 
-export const getIconOptions = attributes => {
+export const getIconOptions = ( attributes, isDeprecated ) => {
 	const {
 		icon,
 		iconColor1,
@@ -55,23 +55,24 @@ export const getIconOptions = attributes => {
 		// If we can't use the generated SVG element for any reason we
 		// display the default icon.
 		return null
-	 }
+	}
 
-	// Remove this since sets the fill to the default color black, even when no color is selected.
-	// svgEl.firstElementChild.setAttribute( 'fill', 'currentColor' )
-	const svgIconSize = iconSize ? parseInt( iconSize, 10 ) : DEFAULT_ICON_SIZE
-	svgEl.setAttribute( 'height', svgIconSize )
-	svgEl.setAttribute( 'width', svgIconSize )
-	svgEl.setAttribute( 'style', `color: ${ iconColor1 || DEFAULT_ICON_COLOR }; opacity: ${ iconOpacity || iconOpacity === 0 ? parseFloat( iconOpacity, 10 ) : DEFAULT_ICON_OPACITY }` )
-	svgEl.setAttribute( 'transform', `rotate(${ iconRotation || iconRotation === 0 ? parseInt( iconRotation, 10 ) : DEFAULT_ICON_ROTATION })` )
-
-	if ( iconColor1 ) {
+	if ( isDeprecated ) {
+		// Deprecate this since sets the fill to the default color black, even when no color is selected.
+		svgEl.firstElementChild.setAttribute( 'fill', 'currentColor' )
+	} else if ( iconColor1 ) {
 		// Apply the fill directly to the SVG shapes
 		const svgShapes = svgEl.querySelectorAll( 'g,path,rect,polygon,ellipse' )
 		svgShapes.forEach( svgShape => {
 			svgShape.setAttribute( 'style', `fill: ${ iconColor1 }` )
 		} )
 	}
+
+	const svgIconSize = iconSize ? parseInt( iconSize, 10 ) : DEFAULT_ICON_SIZE
+	svgEl.setAttribute( 'height', svgIconSize )
+	svgEl.setAttribute( 'width', svgIconSize )
+	svgEl.setAttribute( 'style', `color: ${ iconColor1 || DEFAULT_ICON_COLOR }; opacity: ${ iconOpacity || iconOpacity === 0 ? parseFloat( iconOpacity, 10 ) : DEFAULT_ICON_OPACITY }` )
+	svgEl.setAttribute( 'transform', `rotate(${ iconRotation || iconRotation === 0 ? parseInt( iconRotation, 10 ) : DEFAULT_ICON_ROTATION })` )
 
 	const serializedString = new XMLSerializer().serializeToString( svgEl ) //eslint-disable-line no-undef
 	const iconUrl = `data:image/svg+xml;base64,${ window.btoa( serializedString ) }`

--- a/src/block/map/util.js
+++ b/src/block/map/util.js
@@ -64,10 +64,10 @@ export const getIconOptions = attributes => {
 	svgEl.setAttribute( 'style', `color: ${ iconColor1 || DEFAULT_ICON_COLOR }; opacity: ${ iconOpacity || iconOpacity === 0 ? parseFloat( iconOpacity, 10 ) : DEFAULT_ICON_OPACITY }` )
 	svgEl.setAttribute( 'transform', `rotate(${ iconRotation || iconRotation === 0 ? parseInt( iconRotation, 10 ) : DEFAULT_ICON_ROTATION })` )
 
-	// Apply the fill directly to the path elements
-	const pathElements = svgEl.querySelectorAll( 'path' )
-	pathElements.forEach( pathElement => {
-		pathElement.setAttribute( 'style', `fill: ${ iconColor1 || DEFAULT_ICON_COLOR }; color: ${ iconColor1 || DEFAULT_ICON_COLOR }; opacity: ${ iconOpacity || iconOpacity === 0 ? parseFloat( iconOpacity, 10 ) : DEFAULT_ICON_OPACITY }` )
+	// Apply the fill directly to the SVG shapes
+	const svgShapes = svgEl.querySelectorAll( 'g,path,rect,polygon,ellipse' )
+	svgShapes.forEach( svgShape => {
+		svgShape.setAttribute( 'style', `fill: ${ iconColor1 }` )
 	} )
 
 	const serializedString = new XMLSerializer().serializeToString( svgEl ) //eslint-disable-line no-undef

--- a/src/block/map/util.js
+++ b/src/block/map/util.js
@@ -38,7 +38,7 @@ export const getMapStyles = ( { mapStyle, customMapStyle } ) => {
 	return styleJSON
 }
 
-export const getIconOptions = ( attributes, isDeprecated ) => {
+export const getIconOptions = attributes => {
 	const {
 		icon,
 		iconColor1,
@@ -57,10 +57,8 @@ export const getIconOptions = ( attributes, isDeprecated ) => {
 		return null
 	}
 
-	if ( isDeprecated ) {
-		// Deprecate this since sets the fill to the default color black, even when no color is selected.
-		svgEl.firstElementChild.setAttribute( 'fill', 'currentColor' )
-	} else if ( iconColor1 ) {
+	// Check if svgEl has a fill attribute
+	if ( iconColor1 && svgEl.firstElementChild.getAttribute( 'fill' ) !== 'currentColor' ) {
 		// Apply the fill directly to the SVG shapes
 		const svgShapes = svgEl.querySelectorAll( 'g,path,rect,polygon,ellipse' )
 		svgShapes.forEach( svgShape => {

--- a/src/block/map/util.js
+++ b/src/block/map/util.js
@@ -64,6 +64,12 @@ export const getIconOptions = attributes => {
 	svgEl.setAttribute( 'style', `color: ${ iconColor1 || DEFAULT_ICON_COLOR }; opacity: ${ iconOpacity || iconOpacity === 0 ? parseFloat( iconOpacity, 10 ) : DEFAULT_ICON_OPACITY }` )
 	svgEl.setAttribute( 'transform', `rotate(${ iconRotation || iconRotation === 0 ? parseInt( iconRotation, 10 ) : DEFAULT_ICON_ROTATION })` )
 
+	// Apply the fill directly to the path elements
+	const pathElements = svgEl.querySelectorAll( 'path' )
+	pathElements.forEach( pathElement => {
+		pathElement.setAttribute( 'style', `fill: ${ iconColor1 || DEFAULT_ICON_COLOR }; color: ${ iconColor1 || DEFAULT_ICON_COLOR }; opacity: ${ iconOpacity || iconOpacity === 0 ? parseFloat( iconOpacity, 10 ) : DEFAULT_ICON_OPACITY }` )
+	} )
+
 	const serializedString = new XMLSerializer().serializeToString( svgEl ) //eslint-disable-line no-undef
 	const iconUrl = `data:image/svg+xml;base64,${ window.btoa( serializedString ) }`
 	const iconOptions = { url: iconUrl }

--- a/src/components/icon-search-popover/index.js
+++ b/src/components/icon-search-popover/index.js
@@ -71,6 +71,10 @@ export const cleanSvgString = svgString => {
 		newSvg = newSvg.replace( /\s*<g\s*>([\s\S]*?)<\/g>\s*/gm, '$1' )
 	}
 
+	// Remove width and height attribute so that we can control the size (default to 100%)
+	newSvg = newSvg.replace( /width="[^"]*"/, '' )
+		.replace( /height="[^"]*"/, '' )
+
 	return newSvg
 }
 

--- a/src/components/icon-search-popover/index.js
+++ b/src/components/icon-search-popover/index.js
@@ -72,8 +72,8 @@ export const cleanSvgString = svgString => {
 	}
 
 	// Remove width and height attribute so that we can control the size (default to 100%)
-	newSvg = newSvg.replace( /width="[^"]*"/, '' )
-		.replace( /height="[^"]*"/, '' )
+	newSvg = newSvg.replace( /<svg([^>]*)width=(["'])[^"']*["']([^>]*)/g, '<svg$1$3' )
+		.replace( /<svg([^>]*)height=(["'])[^"']*["']([^>]*)/g, '<svg$1$3' )
 
 	return newSvg
 }


### PR DESCRIPTION
fixes #3103

Details of the issue and the solution: [https://www.notion.so/SVG-icon-only-shows-up-on-some-blocks-with-icon-3103-94b9c7925d1f4eaba8ebb2752f4b1660?pvs=4](https://www.notion.so/SVG-icon-only-shows-up-on-some-blocks-with-icon-3103-94b9c7925d1f4eaba8ebb2752f4b1660?pvs=4)

TLDR: The SVG that can be uploaded by the users might have inline style which takes precedence specially since this can be applied to the lowest level which is the `<path>` element. This PR fixes the issue by applying the `fill` directly to `<path>` to have higher precedence.