### PR TITLE
Fix/accordion highlight

### DIFF
--- a/src/block/accordion/frontend-accordion.js
+++ b/src/block/accordion/frontend-accordion.js
@@ -30,6 +30,10 @@ class StackableAccordion {
 					el.doAnimate = false
 					const preHeight = el.dataset.preHeight
 
+					// Prevent text selection while animating
+					const content = el.querySelector( '.stk-block-accordion__content' )
+					content.style.userSelect = 'none'
+
 					// When inside columns, flex prevents the accordion closing animation, this hack fixes it.
 					const doWrapHack = !! el.closest( '.stk-block-columns' )
 					let wrapper = null
@@ -49,6 +53,22 @@ class StackableAccordion {
 						el.contentEl.anim = el.contentEl.animate( {
 							maxHeight: [ `0px`, `${ height - preHeight }px` ],
 						}, ANIM_OPTS )
+					}
+
+					// When the animation is done, remove text selection from double click
+					// and allow text selection again
+					el.anim.onfinish = el.anim.oncancel = () => {
+						if ( window.getSelection ) {
+							// eslint-disable-next-line @wordpress/no-global-get-selection
+							const selection = window.getSelection()
+							if ( selection.removeAllRanges ) {
+								selection.removeAllRanges()
+							}
+						} else if ( document.selection ) {
+							// For older IE browsers
+							document.selection.empty()
+						}
+						content.style.userSelect = 'auto'
 					}
 
 					if ( doWrapHack ) {

--- a/src/block/accordion/frontend-accordion.js
+++ b/src/block/accordion/frontend-accordion.js
@@ -31,8 +31,7 @@ class StackableAccordion {
 					const preHeight = el.dataset.preHeight
 
 					// Prevent text selection while animating
-					const content = el.querySelector( '.stk-block-accordion__content' )
-					content.style.userSelect = 'none'
+					el.style.userSelect = 'none'
 
 					// When inside columns, flex prevents the accordion closing animation, this hack fixes it.
 					const doWrapHack = !! el.closest( '.stk-block-columns' )
@@ -55,20 +54,9 @@ class StackableAccordion {
 						}, ANIM_OPTS )
 					}
 
-					// When the animation is done, remove text selection from double click
-					// and allow text selection again
+					// When the animation is done, allow text selection again.
 					el.anim.onfinish = el.anim.oncancel = () => {
-						if ( window.getSelection ) {
-							// eslint-disable-next-line @wordpress/no-global-get-selection
-							const selection = window.getSelection()
-							if ( selection.removeAllRanges ) {
-								selection.removeAllRanges()
-							}
-						} else if ( document.selection ) {
-							// For older IE browsers
-							document.selection.empty()
-						}
-						content.style.userSelect = 'auto'
+						el.style.userSelect = 'auto'
 					}
 
 					if ( doWrapHack ) {

--- a/src/block/accordion/style.scss
+++ b/src/block/accordion/style.scss
@@ -26,6 +26,11 @@
 			justify-content: flex-end;
 		}
 	}
+
+	summary.stk-block-column:focus:not(:focus-visible) {
+		outline: none;
+	}
+
 	// Gap between icon and the title.
 	.stk-block-accordion__heading {
 		.stk-block-icon-label .stk-block-heading {

--- a/src/block/accordion/style.scss
+++ b/src/block/accordion/style.scss
@@ -27,6 +27,7 @@
 		}
 	}
 
+	// Remove outline on focus, but keep it for keyboard navigation.
 	summary.stk-block-column:focus:not(:focus-visible) {
 		outline: none;
 	}


### PR DESCRIPTION
fixes #3096

- No outline when clicked, but outline when tabbed for accessibility
