### PR TITLE
fix (image): image stretching for firefox

### DIFF
--- a/src/block-components/image/editor.scss
+++ b/src/block-components/image/editor.scss
@@ -245,6 +245,10 @@
 	// Firefox doesn't stretch SVG masks via attributes, stretching is done here. Fixes #246.
 	&.stk-image--shape-stretch .stk-img-resizer-wrapper {
 		mask-size: 100% 100%;
+		// Firefox doesn't automatically inherit the mask-size from the parent. Fixes #3042.
+		img {
+			mask-size: inherit !important;
+		}
 	}
 }
 

--- a/src/block-components/image/style.scss
+++ b/src/block-components/image/style.scss
@@ -56,6 +56,10 @@
 		&::before {
 			mask-size: 100% 100%;
 		}
+		// Firefox doesn't automatically inherit the mask-size from the parent. Fixes #3042.
+		img {
+			mask-size: inherit !important;
+		}
 	}
 }
 


### PR DESCRIPTION
fixes #3042 