### PR TITLE
fix: Ignore invalid CSS that affects the CSS of subsequent blocks

### DIFF
--- a/src/css-optimize.php
+++ b/src/css-optimize.php
@@ -462,7 +462,17 @@ if ( ! class_exists( 'Stackable_CSS_Optimize' ) ) {
 					// Optimize selectors by combining similar ones.
 					$selector_arr = self::combine_selectors( $selector_arr );
 
-					$css .= implode( ',', $selector_arr ) . $style_rules;
+					$combined_css = implode( ',', $selector_arr ) . $style_rules;
+
+					// Prevent invalid CSS in affecting the rest of the CSS
+					// by closing any open curly braces.
+					$open_curly_brace = substr_count( $combined_css , '{' );
+					$close_curly_brace = substr_count( $combined_css , '}' );
+					if ( $open_curly_brace > $close_curly_brace ) {
+						$combined_css .= str_repeat( '}', $open_curly_brace - $close_curly_brace );
+					}
+
+					$css .= $combined_css;
 				}
 
 				if ( ! empty( $media_query ) ) {

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -227,6 +227,9 @@ export const compileCSS = ( css, mainClass, uniqueID, isEditor = false, deviceTy
 
 					return `${ mediaQuery } ${ newSelector } ${ paren }`
 				} )
+			} else if ( selector.includes( '{' ) ) {
+				// Ignore invalid CSS that affects the CSS of subsequent blocks.
+				return ''
 			}
 
 			const newSelector = prependCSSClass( selector, mainClass, uniqueID )

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -227,9 +227,6 @@ export const compileCSS = ( css, mainClass, uniqueID, isEditor = false, deviceTy
 
 					return `${ mediaQuery } ${ newSelector } ${ paren }`
 				} )
-			} else if ( selector.includes( '{' ) ) {
-				// Ignore invalid CSS that affects the CSS of subsequent blocks.
-				return ''
 			}
 
 			const newSelector = prependCSSClass( selector, mainClass, uniqueID )


### PR DESCRIPTION
fixes #3164 

[notes](https://www.notion.so/Entering-invalid-Custom-CSS-can-break-block-styles-3164-7a027fbc7037417ea71988226691b78e?pvs=4)