### PR TITLE
fix (inner columns): fix flex direction in Firefox polyfill

### DIFF
--- a/src/block-components/alignment/editor.scss
+++ b/src/block-components/alignment/editor.scss
@@ -79,8 +79,3 @@
 	}
 }
 
-.stk-row.stk--alignment-polyfill > :is(.stk-inner-blocks, .stk-block-content):not(.stk--column-flex) {
-	&:not(.stk--block-horizontal-flex) > .block-editor-inner-blocks > .block-editor-block-list__layout {
-		flex-direction: row;
-	}
-}

--- a/src/block-components/alignment/editor.scss
+++ b/src/block-components/alignment/editor.scss
@@ -78,3 +78,9 @@
 		}
 	}
 }
+
+.stk-row.stk--alignment-polyfill > :is(.stk-inner-blocks, .stk-block-content):not(.stk--column-flex) {
+	&:not(.stk--block-horizontal-flex) > .block-editor-inner-blocks > .block-editor-block-list__layout {
+		flex-direction: row;
+	}
+}

--- a/src/styles/editor-block.scss
+++ b/src/styles/editor-block.scss
@@ -147,7 +147,7 @@
  */
 .stk-row > .stk-block-content > .block-editor-inner-blocks > .block-editor-block-list__layout {
 	display: flex;
-	flex-direction: row;
+	flex-direction: row !important;
 	flex-wrap: wrap;
 }
 .stk-row > .stk-block-content > .block-editor-inner-blocks > .block-editor-block-list__layout > div:not(.block-list-appender) {


### PR DESCRIPTION
fixes #3193 

The css rule polyfill has higher specificity so `flex-direction: row` when doesn't get applied even if the block has `.stk-row` class.

Chrome:
<img width="1680" alt="chrome" src="https://github.com/gambitph/Stackable/assets/98727316/8e3cec60-a94f-4186-a440-87ad2936bd5d">

Firefox:
<img width="1257" alt="firefox" src="https://github.com/gambitph/Stackable/assets/98727316/5a1701e4-861e-4fba-a876-fc5c694611e6">
