### PR TITLE
fix: adjust classes and styles of variation picker for wp 6.6

### DIFF
--- a/src/components/variation-picker/editor.scss
+++ b/src/components/variation-picker/editor.scss
@@ -1,6 +1,12 @@
 .stk-variation-picker {
+	.block-editor-block-variation-picker__variations {
+		gap: 16px;
+	}
 	.block-editor-block-variation-picker__variations > li {
-		margin: 8px 20px 0 0;
+		margin: 0;
+	}
+	.stk-stackable-icon-gradient {
+		fill: revert !important;
 	}
 
 	.is-premium {
@@ -14,6 +20,7 @@
 	}
 	.block-editor-block-variation-picker__variation {
 		background: #fff !important;
+		height: 42px;
 
 		svg {
 			width: 48px;

--- a/src/components/variation-picker/editor.scss
+++ b/src/components/variation-picker/editor.scss
@@ -12,8 +12,12 @@
 			fill: #d8d8d8 !important;
 		}
 	}
-	.block-editor-block-variation-picker__variation svg {
-		width: 48px;
-		height: 48px;
+	.block-editor-block-variation-picker__variation {
+		background: #fff !important;
+
+		svg {
+			width: 48px;
+			height: 48px;
+		}
 	}
 }

--- a/src/components/variation-picker/editor.scss
+++ b/src/components/variation-picker/editor.scss
@@ -1,15 +1,19 @@
 .stk-variation-picker {
+	.block-editor-block-variation-picker__variations > li {
+		margin: 8px 20px 0 0;
+	}
+
 	.is-premium {
 		pointer-events: none;
 		~ span {
 			color: #888;
 		}
+		svg {
+			fill: #d8d8d8 !important;
+		}
 	}
 	.block-editor-block-variation-picker__variation svg {
 		width: 48px;
 		height: 48px;
-		* {
-			stroke: currentColor;
-		}
 	}
 }

--- a/src/components/variation-picker/index.js
+++ b/src/components/variation-picker/index.js
@@ -47,10 +47,9 @@ const VariationPicker = props => {
 					{ variations.map( variation => (
 						<li key={ variation.name }>
 							<Button
-								variant="secondary"
+								variant="tertiary"
 								icon={ variation.pickerIcon || variation.icon }
 								iconSize={ 48 }
-								isSecondary
 								onClick={ () => onSelect( variation ) }
 								className={ classnames( 'block-editor-block-variation-picker__variation', {
 									'is-premium': variation.isPremium,


### PR DESCRIPTION
fixes #3219 

Opted to adapt to newer variation picker style. Some style are overwritten to accommodate picker for Stackable blocks:
1. Add margin similar to old version for longer label and compatibility.
2. Make fill of premium variations lighter