### PR TITLE
fix(posts): use uniqueId as stkQueryId to ensure uniqueness even when…

### DIFF
--- a/src/block/posts/edit.js
+++ b/src/block/posts/edit.js
@@ -68,9 +68,9 @@ import { Placeholder, Spinner } from '@wordpress/components'
 import { __ } from '@wordpress/i18n'
 import { applyFilters, addFilter } from '@wordpress/hooks'
 import { InnerBlocks, useBlockEditContext } from '@wordpress/block-editor'
-import { useMemo } from '@wordpress/element'
+import { useMemo, useEffect } from '@wordpress/element'
 import { useSelect } from '@wordpress/data'
-import { compose } from '@wordpress/compose'
+import { compose, useInstanceId } from '@wordpress/compose'
 
 const ALLOWED_INNER_BLOCKS = [
 	'stackable/load-more',
@@ -98,6 +98,7 @@ const Edit = props => {
 	useGeneratedCss( props.attributes )
 
 	const {
+		stkQueryId,
 		imageSize,
 		type = 'post',
 		orderBy = 'date',
@@ -116,6 +117,8 @@ const Edit = props => {
 	const {
 		posts, isRequesting, hasPosts,
 	} = usePostsQuery( attributes )
+
+	const instanceId = useInstanceId( Edit )
 
 	const wrapperClassNames = classnames(
 		'stk-inner-blocks',
@@ -148,10 +151,17 @@ const Edit = props => {
 		return generateRenderPostItem( attributes, { isHovered: props.isHovered } )
 	}, [ attributes, props.isHovered ] )
 
+	useEffect( () => {
+		// Set a unique instance ID for the posts block.
+		// This is used to give unique identifier to our
+		// queries.
+		if ( stkQueryId !== instanceId ) {
+			setAttributes( { stkQueryId: instanceId } )
+		}
+	}, [ stkQueryId, instanceId ] )
+
 	const activeVariation = getActiveBlockVariation( name, attributes )
 	const defaultContentOrder = activeVariation?.attributes?.contentOrder || DEFAULT_ORDER
-
-	setAttributes( { stkQueryId: uniqueId } )
 
 	return (
 		<>

--- a/src/block/posts/edit.js
+++ b/src/block/posts/edit.js
@@ -152,6 +152,7 @@ const Edit = props => {
 	const defaultContentOrder = activeVariation?.attributes?.contentOrder || DEFAULT_ORDER
 
 	setAttributes( { stkQueryId: uniqueId } )
+
 	return (
 		<>
 			<>

--- a/src/block/posts/edit.js
+++ b/src/block/posts/edit.js
@@ -68,9 +68,9 @@ import { Placeholder, Spinner } from '@wordpress/components'
 import { __ } from '@wordpress/i18n'
 import { applyFilters, addFilter } from '@wordpress/hooks'
 import { InnerBlocks, useBlockEditContext } from '@wordpress/block-editor'
-import { useMemo, useEffect } from '@wordpress/element'
+import { useMemo } from '@wordpress/element'
 import { useSelect } from '@wordpress/data'
-import { compose, useInstanceId } from '@wordpress/compose'
+import { compose } from '@wordpress/compose'
 
 const ALLOWED_INNER_BLOCKS = [
 	'stackable/load-more',
@@ -98,7 +98,6 @@ const Edit = props => {
 	useGeneratedCss( props.attributes )
 
 	const {
-		stkQueryId,
 		imageSize,
 		type = 'post',
 		orderBy = 'date',
@@ -117,8 +116,6 @@ const Edit = props => {
 	const {
 		posts, isRequesting, hasPosts,
 	} = usePostsQuery( attributes )
-
-	const instanceId = useInstanceId( Edit )
 
 	const wrapperClassNames = classnames(
 		'stk-inner-blocks',
@@ -151,18 +148,10 @@ const Edit = props => {
 		return generateRenderPostItem( attributes, { isHovered: props.isHovered } )
 	}, [ attributes, props.isHovered ] )
 
-	useEffect( () => {
-		// Set a unique instance ID for the posts block.
-		// This is used to give unique identifier to our
-		// queries.
-		if ( ! stkQueryId ) {
-			setAttributes( { stkQueryId: instanceId } )
-		}
-	}, [ stkQueryId, instanceId ] )
-
 	const activeVariation = getActiveBlockVariation( name, attributes )
 	const defaultContentOrder = activeVariation?.attributes?.contentOrder || DEFAULT_ORDER
 
+	setAttributes( { stkQueryId: uniqueId } )
 	return (
 		<>
 			<>

--- a/src/block/posts/schema.js
+++ b/src/block/posts/schema.js
@@ -29,7 +29,7 @@ import { __ } from '@wordpress/i18n'
 const postsAttributes = {
 	// General.
 	stkQueryId: {
-		type: 'string',
+		type: 'number',
 	},
 	columns: {
 		type: 'number',

--- a/src/block/posts/schema.js
+++ b/src/block/posts/schema.js
@@ -29,7 +29,7 @@ import { __ } from '@wordpress/i18n'
 const postsAttributes = {
 	// General.
 	stkQueryId: {
-		type: 'number',
+		type: 'string',
 	},
 	columns: {
 		type: 'number',


### PR DESCRIPTION
… duplicated

fixes #3189

The problem arises from the `stkQueryId` attribute being also duplicated when the post block is duplicated. Only unique `stkQueryId` is assigned when new post blocks are created using `useInstanceId`.

Question: Is there a reason why in the previous implementation, `uniqueId`, which is always unique, was not used? If so, I can change the implementation to check all post blocks first before assigning `stkQueryId` to ensure uniqueness.