### PR TITLE
fix: lower specificity for hover transitions

### DIFF
--- a/src/styles/block-transitions.scss
+++ b/src/styles/block-transitions.scss
@@ -2,20 +2,20 @@
  * This defines all styles related to making the hover states of blocks animate smoothly.
  */
 // Hover transitions.
-body.stk--anim-init {
-	:is(
+.stk--anim-init {
+	:where(
 	.stk-block,
 	.stk-container,
 	.stk-container-padding,
-	.stk-img-wrapper, // Images.
-	.stk-img-wrapper img, // Images.
+	.stk-img-wrapper, /* Images */
+	.stk-img-wrapper img, /* Images */
 	.stk-block-heading__top-line,
 	.stk-block-heading__bottom-line,
-	.stk-block-posts__item-hide, // For posts transitions
-	.stk-block-posts__title > a, // For posts title
-	.stk-button, // Buttons
-	.stk-button__inner-text, // Button text
-	.stk-block li, // For icon list texts
+	.stk-block-posts__item-hide, /* For posts transitions */
+	.stk-block-posts__title > a, /* For posts title */
+	.stk-button, /* Buttons */
+	.stk-button__inner-text, /* Button text */
+	.stk-block li, /* For icon list texts */
 	.stk-block p,
 	.stk-block h1,
 	.stk-block h2,
@@ -24,7 +24,7 @@ body.stk--anim-init {
 	.stk-block h5,
 	.stk-block h6,
 	.stk-block [class*="__text"]), // Text inside blocks.
-	// These are outside :is() since pseudo elements won't compile correctly.
+	// These are outside :where() since pseudo elements won't compile correctly.
 	.stk--has-background-overlay::before, // Image background overlays
 	.stk-block .stk-button::before, // For button animations
 	.stk-block .stk-button::after, // For button animations

--- a/src/styles/block-transitions.scss
+++ b/src/styles/block-transitions.scss
@@ -32,16 +32,16 @@
 	.stk-img-wrapper::before, // Image block hover ovelay.
 	.stk-block li::marker, // For icon list marker
 	.stk-block-tabs__tab { // Tabs block
-		transition: all var(--stk-transition-duration, 0.12s) cubic-bezier(0.45, 0.05, 0.55, 0.95), flex 0s, max-width 0s, visibility 0s; // Don't include flex & max-width since column widths would animate.
+		transition: var(--stk-transition-default, all var(--stk-transition-duration, 0.12s) cubic-bezier(0.45, 0.05, 0.55, 0.95), flex 0s, max-width 0s, visibility 0s);
 		border-width: 1px;
 		border-style: none;
 	}
 	.stk--svg-wrapper :is(.stk--shape-icon, .stk--inner-svg, .stk--inner-svg *) {
-		transition: all var(--stk-transition-duration, 0.12s) cubic-bezier(0.45, 0.05, 0.55, 0.95);
+		transition: var(--stk-transition-default, all var(--stk-transition-duration, 0.12s) cubic-bezier(0.45, 0.05, 0.55, 0.95));
 	}
 	// Icons can have a delay in transitions. It's more apparent when transitioning fill, removing it seems to fix this.
 	.stk--svg-wrapper .stk--inner-svg svg:last-child {
-		transition: all var(--stk-transition-duration, 0.12s) cubic-bezier(0.45, 0.05, 0.55, 0.95), fill 0s;
+		transition: var(--stk-transition-default, all var(--stk-transition-duration, 0.12s) cubic-bezier(0.45, 0.05, 0.55, 0.95), fill 0s);
 	}
 }
 

--- a/src/styles/block-transitions.scss
+++ b/src/styles/block-transitions.scss
@@ -2,20 +2,20 @@
  * This defines all styles related to making the hover states of blocks animate smoothly.
  */
 // Hover transitions.
-.stk--anim-init {
-	:where(
+body.stk--anim-init {
+	:is(
 	.stk-block,
 	.stk-container,
 	.stk-container-padding,
-	.stk-img-wrapper, /* Images */
-	.stk-img-wrapper img, /* Images */
+	.stk-img-wrapper, // Images.
+	.stk-img-wrapper img, // Images.
 	.stk-block-heading__top-line,
 	.stk-block-heading__bottom-line,
-	.stk-block-posts__item-hide, /* For posts transitions */
-	.stk-block-posts__title > a, /* For posts title */
-	.stk-button, /* Buttons */
-	.stk-button__inner-text, /* Button text */
-	.stk-block li, /* For icon list texts */
+	.stk-block-posts__item-hide, // For posts transitions
+	.stk-block-posts__title > a, // For posts title
+	.stk-button, // Buttons
+	.stk-button__inner-text, // Button text
+	.stk-block li, // For icon list texts
 	.stk-block p,
 	.stk-block h1,
 	.stk-block h2,
@@ -24,7 +24,7 @@
 	.stk-block h5,
 	.stk-block h6,
 	.stk-block [class*="__text"]), // Text inside blocks.
-	// These are outside :where() since pseudo elements won't compile correctly.
+	// These are outside :is() since pseudo elements won't compile correctly.
 	.stk--has-background-overlay::before, // Image background overlays
 	.stk-block .stk-button::before, // For button animations
 	.stk-block .stk-button::after, // For button animations

--- a/src/styles/block-transitions.scss
+++ b/src/styles/block-transitions.scss
@@ -32,7 +32,7 @@ body.stk--anim-init {
 	.stk-img-wrapper::before, // Image block hover ovelay.
 	.stk-block li::marker, // For icon list marker
 	.stk-block-tabs__tab { // Tabs block
-		transition: var(--stk-transition-default, all var(--stk-transition-duration, 0.12s) cubic-bezier(0.45, 0.05, 0.55, 0.95), flex 0s, max-width 0s, visibility 0s);
+		transition: var(--stk-transition-default, all var(--stk-transition-duration, 0.12s) cubic-bezier(0.45, 0.05, 0.55, 0.95), flex 0s, max-width 0s, visibility 0s); // Don't include flex & max-width since column widths would animate.
 		border-width: 1px;
 		border-style: none;
 	}


### PR DESCRIPTION
fixes #3266 

![image](https://github.com/user-attachments/assets/035af942-5fae-41dc-9fdc-51072f422d18)

- Lowers specificity to from (0,3,1) to (0,1,0)
- Added the variable `--stk-transition-default` that can be used for overwriting the transition property