### PR TITLE
fix/3109 query loop class

### DIFF
--- a/src/block-components/content-align/use-content-align.js
+++ b/src/block-components/content-align/use-content-align.js
@@ -4,10 +4,15 @@
 import { applyFilters } from '@wordpress/hooks'
 import classnames from 'classnames'
 
-export const getContentAlignmentClasses = ( attributes, blockName = 'column' ) => {
+export const getContentAlignmentClasses = ( attributes, instanceId, blockName = 'column' ) => {
+	let instanceIdString = ''
+	if ( instanceId ) {
+		instanceIdString = `${ instanceId }-`
+	}
+
 	return classnames(
 		'stk-content-align',
-		`stk-${ attributes.uniqueId }-${ blockName }`,
+		`stk-${ attributes.uniqueId }-${ instanceIdString }${ blockName }`,
 		applyFilters( 'stackable.block-components.content-align.getContentAlignmentClasses', {
 			'stk--flex': attributes.columnJustify,
 			alignwide: attributes.innerBlockContentAlign === 'alignwide', // This will align the columns inside.

--- a/src/block-components/content-align/use-content-align.js
+++ b/src/block-components/content-align/use-content-align.js
@@ -4,7 +4,7 @@
 import { applyFilters } from '@wordpress/hooks'
 import classnames from 'classnames'
 
-export const getContentAlignmentClasses = ( attributes, instanceId, blockName = 'column' ) => {
+export const getContentAlignmentClasses = ( attributes, blockName = 'column', instanceId = '' ) => {
 	let instanceIdString = ''
 	if ( instanceId ) {
 		instanceIdString = `${ instanceId }-`

--- a/src/block/columns/edit.js
+++ b/src/block/columns/edit.js
@@ -81,7 +81,7 @@ const Edit = props => {
 		'stk-inner-blocks',
 		blockAlignmentClass,
 		'stk-block-content',
-	], getContentAlignmentClasses( props.attributes, instanceId ) )
+	], getContentAlignmentClasses( props.attributes, 'column', instanceId ) )
 
 	return (
 		<>

--- a/src/block/columns/edit.js
+++ b/src/block/columns/edit.js
@@ -41,6 +41,7 @@ import {
 	withBlockWrapperIsHovered,
 	withQueryLoopContext,
 } from '~stackable/higher-order'
+import { useQueryLoopInstanceId } from '~stackable/util'
 
 /**
  * WordPress dependencies
@@ -74,11 +75,13 @@ const Edit = props => {
 			columnTooltipClass,
 		], props ) )
 
+	const instanceId = useQueryLoopInstanceId( props.attributes.uniqueId )
+
 	const contentClassNames = classnames( [
 		'stk-inner-blocks',
 		blockAlignmentClass,
 		'stk-block-content',
-	], getContentAlignmentClasses( props.attributes ) )
+	], getContentAlignmentClasses( props.attributes, instanceId ) )
 
 	return (
 		<>

--- a/src/block/horizontal-scroller/edit.js
+++ b/src/block/horizontal-scroller/edit.js
@@ -88,7 +88,7 @@ const Edit = props => {
 		'stk-inner-blocks',
 		blockAlignmentClass,
 		'stk-block-content',
-	 ], getContentAlignmentClasses( props.attributes, instanceId, 'horizontal-scroller' ), {
+	 ], getContentAlignmentClasses( props.attributes, 'horizontal-scroller', instanceId ), {
 		'stk--with-scrollbar': showScrollbar,
 	 } )
 

--- a/src/block/horizontal-scroller/edit.js
+++ b/src/block/horizontal-scroller/edit.js
@@ -43,6 +43,7 @@ import {
 	withBlockWrapperIsHovered,
 	withQueryLoopContext,
 } from '~stackable/higher-order'
+import { useQueryLoopInstanceId } from '~stackable/util'
 
 /**
  * WordPress dependencies
@@ -81,11 +82,13 @@ const Edit = props => {
 		 columnTooltipClass,
 	 ] )
 
+	 const instanceId = useQueryLoopInstanceId( props.attributes.uniqueId )
+
 	 const contentClassNames = classnames( [
 		'stk-inner-blocks',
 		blockAlignmentClass,
 		'stk-block-content',
-	 ], getContentAlignmentClasses( props.attributes, 'horizontal-scroller' ), {
+	 ], getContentAlignmentClasses( props.attributes, instanceId, 'horizontal-scroller' ), {
 		'stk--with-scrollbar': showScrollbar,
 	 } )
 


### PR DESCRIPTION
fixes #3109

Note that the issue is also arises in the Horizontal Scroller Block.

- The class of blocks for styling in the editor looks like this: `stk-abc1234`
	- For blocks inside Query Loop, instanceId is added like this: `stk-abc1234-1`, `stk-abc1234-2`, etc.
	- These are targeted properly in the `BlockCSS `(found in style tag) providing styles in the editor
- However, for Columns and Horizontal Scroller Block, the targeted class (found in style tag) for styling looks like this respectively: `stk-abc1234-column` and `stk-abc1234-horizontal-scroller`
	- If inside Query Loop, instanceId is added like this: `stk-abc1234-1-column`, `stk-abc1234-2-column`, etc.
	- However, instanceId is not considered in generating the class (implemented via `getContentAlignmentClasses`).
	- Solution is to add appropriate instanceId to the generated class.
