### PR TITLE
fix: editing/adding global colors when blocks are present is slow

### DIFF
--- a/src/components/color-palette-control/index.js
+++ b/src/components/color-palette-control/index.js
@@ -143,12 +143,24 @@ const ColorPaletteControl = memo( props => {
 	value = applyFilters( 'stackable.color-palette-control.color-value', value )
 
 	let colorLabel,
-		colorName = value
+		colorName = value,
+		popupPickerValue = value // We assign a value to this so that the popup picker will show a "check" on the selected color.
+
 	allColors.some( color => {
 		if ( color.color === value || color.gradient === value ) {
 			colorName = color.name
 			colorLabel = color.name
 			return true
+		}
+
+		// For Stackable global colors to have a correct name label.
+		if ( color.slug ) {
+			if ( `var(--${ color.slug })` === value ) {
+				colorName = color.name
+				colorLabel = color.name
+				popupPickerValue = color.color
+				return true
+			}
 		}
 		return false
 	} )
@@ -162,7 +174,7 @@ const ColorPaletteControl = memo( props => {
 
 	const colorPalette = (
 		<ColorPalettePopup
-			value={ value }
+			value={ popupPickerValue }
 			onChange={ onChange }
 			preOnChange={ props.preOnChange }
 			colors={ props.isGradient ? gradients : colors }

--- a/src/plugins/global-settings/colors/color-picker.js
+++ b/src/plugins/global-settings/colors/color-picker.js
@@ -4,7 +4,6 @@
 import {
 	getRgb,
 	createColor,
-	updateFallbackBlockAttributes,
 	convertGlobalColorBlockAttributesToStatic,
 } from './util'
 
@@ -75,8 +74,9 @@ const ColorPickers = props => {
 	 * @param {Array} newColors colors passed.
 	 */
 	const updateColors = newColors => {
+		// NOTE: Removed this because it is slow to update all blocks.
 		// Update the blocks in our page.
-		updateFallbackBlockAttributes( newColors )
+		// updateFallbackBlockAttributes( newColors )
 
 		// Save settings.
 		clearTimeout( saveTimeout )

--- a/src/plugins/global-settings/colors/index.js
+++ b/src/plugins/global-settings/colors/index.js
@@ -144,7 +144,7 @@ addFilter( 'stackable.global-settings.inspector', 'stackable/global-colors', out
 // Convert hex colors to global colors in Stackable blocks.
 addFilter( 'stackable.color-palette-control.change', 'stackable/global-colors', ( value, colorObject ) => {
 	if ( colorObject && colorObject.slug.includes( 'stk-global-color' ) ) {
-		return `var(--${ colorObject.slug }, ${ colorObject.color })`
+		return `var(--${ colorObject.slug })`
 	}
 
 	return value


### PR DESCRIPTION
Adjustments:
- When adding global colors, fallback colors will no longer be updated
- When using global colors, fallback colors will no longer be added

Here's what this adjustment looks like:
```diff
- color: var(--stk-global-color-1234, #ff00ff);
+ color: var(--stk-global-color-1234);
```