### PR TITLE
Fix String Translation in index.js

### DIFF
--- a/src/components/variation-picker/index.js
+++ b/src/components/variation-picker/index.js
@@ -18,7 +18,7 @@ const VariationPicker = props => {
 	const {
 		icon = layout,
 		label = __( 'Choose variation' ), // Dev note: no text domain here since this will use WP's translation.
-		instructions = __( 'Select a variation to start with.' ), // Dev note: no text domain here since this will use WP's translation.
+		instructions = __( 'Select a variation to start with.', i18n ),
 		variations,
 		onSelect,
 		allowSkip,


### PR DESCRIPTION
Hello @bfintal 

Fix String Translation in index.js

Added the text domain to this string because it is no longer present among the [default ones in WordPress 6.6.x](https://translate.wordpress.org/consistency/?search=Select+a+variation+to+start+with.&set=it%2Fdefault&project=).

Fix #3433 