### PR TITLE
fix (carousel block): display correct column arrangement

### DIFF
--- a/src/block/carousel/style.scss
+++ b/src/block/carousel/style.scss
@@ -22,7 +22,7 @@
 	&.stk--is-slide[data-slides-to-show="1"] {
 		--gap: 0px;
 	}
-	.stk-block-carousel__slider .stk-block-column {
+	.stk-block-carousel__slider > .stk-block-column {
 		// Reset column order of carousel inner columns in case carousel is in columns block.
 		order: initial;
 	}


### PR DESCRIPTION
fixes #3327 

related to #3267 