### PR TITLE
Fix (WP 6.7 - Countdown Block): Fix color of selected date

### DIFF
--- a/src/block/countdown/editor.scss
+++ b/src/block/countdown/editor.scss
@@ -9,6 +9,12 @@
 }
 
 .ugb-panel--countdown .components-datetime__date {
+	.components-datetime__date__day[aria-label*="Selected" i] {
+		color: #fff;
+		&:hover {
+			color: #fff !important;
+		}
+	}
 	:last-child {
 		row-gap: 8px;
 		column-gap: 4px;


### PR DESCRIPTION
fixes #3357 