### PR TITLE
fix (icon label): return false for isEligible if there is no icon block

### DIFF
--- a/src/block/icon-label/deprecated.js
+++ b/src/block/icon-label/deprecated.js
@@ -12,6 +12,10 @@ const deprecated = [
 		attributes: attributes( '3.13.1' ),
 		save: withVersion( '3.13.1' )( Save ),
 		isEligible: ( attributes, innerBlocks ) => {
+			if ( innerBlocks[ 0 ]?.name !== 'stackable/icon' ) {
+				return false
+			}
+
 			const iconBlockAttributes = innerBlocks[ 0 ].attributes
 			const hasIconSize = iconBlockAttributes.iconSize || iconBlockAttributes.iconSizeTablet || iconBlockAttributes.iconSizeMobile ? true : false
 			const hasIconGap = attributes.iconGap || attributes.iconGapTablet || attributes.iconGapMobile ? true : false


### PR DESCRIPTION
if icon label is modified and does not have icon block, `isEligible` returns an error. 

This fix checks if the icon label's inner block contains icon block.