### PR TITLE
feat/3376 fix/2955 image alt

### DIFF
--- a/src/block-components/image/edit.js
+++ b/src/block-components/image/edit.js
@@ -137,7 +137,7 @@ const Controls = props => {
 							imageWidthAttribute: width,
 							imageHeightAttribute: height,
 							imageExternalUrl: '',
-							...( attributes.imageAlt ? {} : { imageAlt: image.alt || '' } ), // Only set the alt if it's empty.
+							...( image.alt ? { imageAlt: image.alt || '' } : {} ), // Only overwrite current alt if new alt is not empty.
 						} )
 					} }
 				/>

--- a/src/block-components/image/image.js
+++ b/src/block-components/image/image.js
@@ -269,7 +269,7 @@ const Image = memo( props => {
 					onError={ () => setHasImageError( true ) }
 					className={ imageClasses }
 					src={ src || undefined }
-					alt={ striptags( props.alt || undefined ) }
+					alt={ striptags( props.alt || '' ) }
 					title={ striptags( props.title || undefined ) }
 					width={ props.width || undefined }
 					height={ props.height || undefined }
@@ -438,10 +438,10 @@ const ImageContent = props => {
 		: undefined
 
 	const propsToPass = {}
-	const alt = striptags( props.alt || undefined )
-	if ( alt ) {
-		propsToPass.alt = alt
-	}
+
+	// Allow explicit empty string for accessibility
+	propsToPass.alt = striptags( props.alt || '' )
+
 	const title = striptags( props.title || undefined )
 	if ( title ) {
 		propsToPass.title = title

--- a/src/block-components/image/use-image.js
+++ b/src/block-components/image/use-image.js
@@ -1,13 +1,10 @@
 /**
  * WordPress Dependencies
  */
-import { useBlockAttributesContext, useBlockSetAttributesContext } from '~stackable/hooks'
+import { useBlockSetAttributesContext } from '~stackable/hooks'
 
 export const useImage = () => {
 	const setAttributes = useBlockSetAttributesContext()
-	const attributes = useBlockAttributesContext( attributes => ( {
-		imageAlt: attributes.imageAlt,
-	} ) )
 
 	const onChange = image => {
 		setAttributes( {
@@ -16,7 +13,7 @@ export const useImage = () => {
 			imageHeightAttribute: image.height,
 			imageWidthAttribute: image.width,
 			imageExternalUrl: '',
-			...( attributes.imageAlt ? {} : { imageAlt: image.alt || '' } ), // Only add the image alt if it's empty.
+			...( image.alt ? { imageAlt: image.alt || '' } : {} ), // Only overwrite current alt if new alt is not empty.
 		} )
 	}
 


### PR DESCRIPTION
fixes #2955 
fixes #3376

The fix for #2955 also considers the expected behavior from the previous issue #2524. That is: 
- If uploaded media library image has existing alt text, should overwrite custom alt text
- If uploaded media library image has no alt text (empty or blank), should NOT overwrite custom alt text

For #3376, we should allow explicit empty string for `alt `since the Image Alt Text Box: ![image](https://github.com/user-attachments/assets/953e2cf6-142f-4e8d-a13a-217afb711d1e) links the W3 Alt  standard (similar to native Image) which says empty string for `alt` (decorative) has different interpretation compared to undefined `alt`.
