### PR TITLE
fix: revert fix to icon list item, use splitting instead

### DIFF
--- a/src/block/icon-list-item/edit.js
+++ b/src/block/icon-list-item/edit.js
@@ -5,7 +5,6 @@ import blockStyles from './style'
 import { getUseSvgDef } from '../icon-list/util'
 import {
 	convertToListItems,
-	useOnPaste,
 	useEnter,
 } from './util'
 
@@ -110,7 +109,6 @@ const Edit = props => {
 	] )
 
 	const useEnterRef = useEnter( text, clientId )
-	const onPaste = useOnPaste( clientId, parentBlock?.clientId, attributes, setAttributes )
 
 	const onMerge = forward => {
 		mergeBlocks( forward )
@@ -173,7 +171,6 @@ const Edit = props => {
 						tagName="span"
 						className={ textClassNames }
 						onMerge={ onMerge }
-						onPaste={ onPaste }
 						onReplace={ onReplace
 							? ( blocks, ...args ) => {
 								onReplace(

--- a/src/block/icon-list-item/util.js
+++ b/src/block/icon-list-item/util.js
@@ -3,16 +3,16 @@
  * WordPress dependencies
  */
 import { useRefEffect } from '@wordpress/compose'
-import { useCallback, useRef } from '@wordpress/element'
+import { useRef } from '@wordpress/element'
 import {
-	useSelect, useDispatch, dispatch,
+	useSelect,
+	useDispatch,
 } from '@wordpress/data'
 import {
 	cloneBlock,
 	switchToBlockType,
 	createBlock,
 	getDefaultBlockName,
-	pasteHandler,
 } from '@wordpress/blocks'
 import { store as blockEditorStore } from '@wordpress/block-editor'
 import { ENTER } from '@wordpress/keycodes'
@@ -122,45 +122,4 @@ export const useEnter = ( text, clientId ) => {
 		},
 		[ clientId ]
 	)
-}
-
-export const useOnPaste = ( clientId, parentClientId, attributes, setAttributes ) => {
-	const { insertBlocks } = useDispatch( blockEditorStore )
-	const { getBlockIndex } = useSelect( blockEditorStore )
-
-	return useCallback( event => {
-		event.preventDefault()
-		const html = event.clipboardData.getData( 'text/html' )
-		const plain = event.clipboardData.getData( 'text/plain' )
-
-		// Convert first to core/list block.
-		const list = pasteHandler( {
-			HTML: html,
-			plainText: plain,
-			mode: 'BLOCKS',
-		} )
-
-		// If list[0] has inner blocks, it has been converted to core/list block, else list has core/paragraph elements.
-		const items = list[ 0 ].innerBlocks.length ? list[ 0 ].innerBlocks : list
-
-		const content = items.map( item => item.attributes.content.toPlainText().replaceAll( '\n', '<br>' ) )
-
-		// If current icon list item has no text, use the first item as text.
-		if ( ! attributes.text ) {
-			const firstItem = content.shift()
-			setAttributes( { text: firstItem } )
-		}
-
-		// create new icon list items
-		const newBlocks = content.map( text => {
-			const block = createBlock( 'stackable/icon-list-item', {
-				...attributes,
-				text,
-			} )
-
-			return block
-		} )
-		dispatch( 'core/block-editor' ).__unstableMarkNextChangeAsNotPersistent()
-		insertBlocks( newBlocks, getBlockIndex( clientId ) + 1, parentClientId )
-	}, [ clientId, parentClientId, attributes, setAttributes ] )
 }


### PR DESCRIPTION
fixes #3382 

- The [previous PR](https://github.com/gambitph/Stackable/pull/3230) on `onPaste` causes the issue
    - Removing the code fixes current the issue, including other issues such as pasting always do line breaks
    - The issue in the previous PR (pasting multiple line of list only paste a single line of `Icon List Item`) is more about splitting.
        - This can be fixed by using `supports: { splitting: true }` instead, which was already done with the previous [deprecation fixes](https://github.com/gambitph/Stackable/commit/75f280151c9964c598a821c2c55bd964ffc783f6)
- Testing:
    - Previous Issue: Pasting from other lists now splits. Tested with Google docs list, WordPress List block, or Stackable Icon List block ✅
    - Current Issue: Pasting now puts the cursor at the end of the line ✅
    - Additional Issue: Pasting now does not force a line break ✅