### PR TITLE
fix (columns): disallow column order from spilling over to nested column blocks

### DIFF
--- a/src/block/accordion/style.scss
+++ b/src/block/accordion/style.scss
@@ -99,6 +99,12 @@
 		transform: translateY(25px);
 		opacity: 0;
 	}
+
+	// Prevent inside columns from being re-ordered when a parent column block
+	// has custom ordering.
+	> .stk-block-column {
+		order: initial !important;
+	}
 }
 
 // This is for the column hack. Remove margin for the wrapper div if accordion is inside a columns block

--- a/src/block/columns/style.scss
+++ b/src/block/columns/style.scss
@@ -19,9 +19,9 @@
 // the column order from spilling to nested blocks.
 // Target the stk-column-wrapper to also include blocks with column innerblocks
 // but are not columns (no stk-block-columns), like accordion and horizontal scroller.
-:where(.stk-column-wrapper) {
+:where(.stk-block-columns) {
 	@for $i from 1 through 20 {
-		--stk-col-order-#{ $i }: initial;
+		--stk-col-order-#{ $i }: #{ $i };
 	}
 }
 

--- a/src/block/columns/style.scss
+++ b/src/block/columns/style.scss
@@ -17,9 +17,11 @@
 
 // Add a 0 specificity style to set the default column order. This is to prevent
 // the column order from spilling to nested blocks.
-:where(.stk-block-columns) {
+// Target the stk-column-wrapper to also include blocks with column innerblocks
+// but are not columns (no stk-block-columns), like accordion and horizontal scroller.
+:where(.stk-column-wrapper) {
 	@for $i from 1 through 20 {
-		--stk-col-order-#{ $i }: #{ $i };
+		--stk-col-order-#{ $i }: initial;
 	}
 }
 

--- a/src/block/columns/style.scss
+++ b/src/block/columns/style.scss
@@ -15,6 +15,14 @@
 	margin-right: auto;
 }
 
+// Add a 0 specificity style to set the default column order. This is to prevent
+// the column order from spilling to nested blocks.
+:where(.stk-block-columns) {
+	@for $i from 1 through 20 {
+		--stk-col-order-#{ $i }: #{ $i };
+	}
+}
+
 // Column order.
 @for $i from 1 through 20 {
 	.stk-block-column:nth-child(#{ $i }) {


### PR DESCRIPTION
fixes https://github.com/gambitph/Stackable/issues/3398
fixes https://github.com/gambitph/Stackable/issues/3406

This is an alternative solution to #3416