### PR TITLE
feat (custom breakpoints): remove the render_block filter to prevent future checks

### DIFF
--- a/src/dynamic-breakpoints.php
+++ b/src/dynamic-breakpoints.php
@@ -246,6 +246,7 @@ if ( ! class_exists( 'Stackable_Dynamic_Breakpoints' ) ) {
 		 */
 		public function adjust_block_styles( $block_content, $block ) {
 			if ( ! $this->has_custom_breakpoints() ) {
+				remove_filter( 'render_block', array( $this, 'adjust_block_styles' ), 11 );
 				return $block_content;
 			}
 


### PR DESCRIPTION
if no custom breakpoints, remove the render_block filter to prevent future checks.

Things need to be checked:
- Blocksy's breakpoints
- Custom breakpoints set in Blocksy
- Custom breakpoints set in Stackable settings
- If no custom breakpoints