### PR TITLE
fix: auto-deactivate other active Stackable plugin

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -30,6 +30,11 @@ if ( defined('STACKABLE_FILE') && STACKABLE_FILE !== __FILE__ && ! isset( $GLOBA
 	// Get relative file path of the other Stackable version.
 	$GLOBALS['OTHER_STACKABLE_FILE'] = plugin_basename( STACKABLE_FILE );
 
+	// Use a temporary option to store the other Stackable Plugin info needed for the admin notice. This will be deleted later.
+	// Note: We cannot use add_action in the register_activation_hook callback so we use this temporary option.
+	// See https://developer.wordpress.org/reference/functions/register_activation_hook/#process-flow for more info.
+	add_option( 'stackable_other_stackable_plugin_info', [ 'BUILD' => STACKABLE_BUILD, 'VERSION' => STACKABLE_VERSION ] );
+
 	register_activation_hook( __FILE__, 'stackable_multiple_plugins_check' );
 }
 
@@ -172,6 +177,28 @@ if ( ! function_exists( 'stackable_notice_gutenberg_plugin_ignore' ) ) {
 		update_option( 'stackable_notice_gutenberg_plugin_ignore', true );
 	}
 	add_action( 'wp_ajax_stackable_notice_gutenberg_plugin_ignore', 'stackable_notice_gutenberg_plugin_ignore' );
+}
+
+/**
+ * Show notice if another Stackable plugin has been deactivated.
+ *
+ * @since 3.18.1
+ */
+if ( ! function_exists( 'stackable_notice_other_stackable_plugin_deactivated' ) ) {
+    function stackable_notice_other_stackable_plugin_deactivated() {
+        $OTHER_STACKABLE_INFO = get_option( 'stackable_other_stackable_plugin_info', false );
+        if ( $OTHER_STACKABLE_INFO ) {
+            printf(
+                '<div class="notice notice-info is-dismissible stackable_notice_gutenberg_plugin"><p>%s</p></div>',
+                sprintf( esc_html__( '%sStackable Notice%s: The Stackable plugin (%s version %s) has been deactivated. Only one active Stackable plugin is needed.', STACKABLE_I18N ), '<strong>', '</strong>', $OTHER_STACKABLE_INFO['BUILD'], $OTHER_STACKABLE_INFO['VERSION'] )
+            );
+            delete_option( 'stackable_other_stackable_plugin_info' );
+        }
+	}
+
+	if ( get_option( 'stackable_other_stackable_plugin_info', false ) ) {
+		add_action( 'admin_notices', 'stackable_notice_other_stackable_plugin_deactivated' );
+	}
 }
 
 /********************************************************************************************

--- a/plugin.php
+++ b/plugin.php
@@ -28,8 +28,7 @@ if ( ! function_exists( 'stackable_multiple_plugins_check' ) ) {
 
 if ( defined('STACKABLE_FILE') && STACKABLE_FILE !== __FILE__ && ! isset( $GLOBALS['OTHER_STACKABLE_FILE'] ) ) {
 	// Get relative file path of the other Stackable version.
-	preg_match( "#([^\/]*?\/plugin.php)$#", STACKABLE_FILE, $matches );
-	$GLOBALS['OTHER_STACKABLE_FILE'] = $matches[1];
+	$GLOBALS['OTHER_STACKABLE_FILE'] = plugin_basename( STACKABLE_FILE );
 
 	register_activation_hook( __FILE__, 'stackable_multiple_plugins_check' );
 }

--- a/plugin.php
+++ b/plugin.php
@@ -19,8 +19,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // Freemius SDK: Auto deactivate the free version when activating the paid one.
 if ( function_exists( 'sugb_fs' ) ) {
-	sugb_fs()->set_basename( true, __FILE__ );
-	return;
+	 // Prevent PHP errors by checking sugb_fs return value.
+    // In the free version, sugb_fs() is a no-op function that returns null.
+    // Only proceed if sugb_fs() returns an object (i.e., the Freemius SDK is loaded).
+    if ( is_object( sugb_fs() ) ) {
+        sugb_fs()->set_basename( false, __FILE__ );
+        return;
+    }
 }
 
 defined( 'STACKABLE_SHOW_PRO_NOTICES' ) || define( 'STACKABLE_SHOW_PRO_NOTICES', true );
@@ -213,6 +218,11 @@ if ( ! function_exists( 'is_frontend' ) ) {
  */
 if ( STACKABLE_BUILD !== 'free' ) {
 	require_once( plugin_dir_path( __FILE__ ) . 'freemius.php' );
+} else if ( ! function_exists( 'sugb_fs' ) ) {
+    // Provide a no-op sugb_fs() stub for compatibility when Freemius SDK is not loaded.
+    // This allows themes and plugins to safely check for Stackable's presence.
+    // The function returns null and performs no actions.
+    function sugb_fs() {};
 }
 
 /**

--- a/plugin.php
+++ b/plugin.php
@@ -17,15 +17,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! function_exists( 'stackable_multiple_plugins_check' ) ) {
+	// Prevent multiple Stackable plugin versions from being active simultaneously.
+	function stackable_multiple_plugins_check() {
+		if ( is_plugin_active( $GLOBALS['OTHER_STACKABLE_FILE'] ) ) {
+			deactivate_plugins( $GLOBALS['OTHER_STACKABLE_FILE'] );
+		}
+	}
+}
+
+if ( defined('STACKABLE_FILE') && STACKABLE_FILE !== __FILE__ && ! isset( $GLOBALS['OTHER_STACKABLE_FILE'] ) ) {
+	// Get relative file path of the other Stackable version.
+	preg_match( "#([^\/]*?\/plugin.php)$#", STACKABLE_FILE, $matches );
+	$GLOBALS['OTHER_STACKABLE_FILE'] = $matches[1];
+
+	register_activation_hook( __FILE__, 'stackable_multiple_plugins_check' );
+}
+
 // Freemius SDK: Auto deactivate the free version when activating the paid one.
 if ( function_exists( 'sugb_fs' ) ) {
-	 // Prevent PHP errors by checking sugb_fs return value.
-    // In the free version, sugb_fs() is a no-op function that returns null.
-    // Only proceed if sugb_fs() returns an object (i.e., the Freemius SDK is loaded).
-    if ( is_object( sugb_fs() ) ) {
-        sugb_fs()->set_basename( false, __FILE__ );
-        return;
-    }
+	sugb_fs()->set_basename( true, __FILE__ );
+	return;
 }
 
 defined( 'STACKABLE_SHOW_PRO_NOTICES' ) || define( 'STACKABLE_SHOW_PRO_NOTICES', true );
@@ -218,11 +230,6 @@ if ( ! function_exists( 'is_frontend' ) ) {
  */
 if ( STACKABLE_BUILD !== 'free' ) {
 	require_once( plugin_dir_path( __FILE__ ) . 'freemius.php' );
-} else if ( ! function_exists( 'sugb_fs' ) ) {
-    // Provide a no-op sugb_fs() stub for compatibility when Freemius SDK is not loaded.
-    // This allows themes and plugins to safely check for Stackable's presence.
-    // The function returns null and performs no actions.
-    function sugb_fs() {};
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic conflict detection when multiple Stackable versions are active. The plugin now deactivates the other active version to prevent issues and ensure stability.
  * Displays a one-time admin notice after deactivation, clearly indicating which version was disabled, including build/version details.
  * Runs on activation and stores temporary info to support the notification, providing transparency without requiring manual checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->