### PR TITLE
fix: when doing a rest api call, a php error stackable_add_welcome_notification is undefined can trigger

### DIFF
--- a/src/pro.php
+++ b/src/pro.php
@@ -87,8 +87,10 @@ if ( ! class_exists( 'Stackable_Go_Premium_Notification' ) ) {
 		const OLD_TIMER_NOTICE_TIME = 604800; // 7 * 24 * 60 * 60
 
         function __construct() {
-            add_action( 'admin_menu', array( $this, 'check_pro_notice_date' ), 9 );
-			add_action( 'admin_menu', array( $this, 'go_premium_notice_old_raters' ), 9 );
+            if ( is_admin() ) {
+				add_action( 'admin_menu', array( $this, 'check_pro_notice_date' ), 9 );
+				add_action( 'admin_menu', array( $this, 'go_premium_notice_old_raters' ), 9 );
+			}
         }
 
         /**

--- a/src/welcome/notification-rate.php
+++ b/src/welcome/notification-rate.php
@@ -21,7 +21,9 @@ if ( ! class_exists( 'Stackable_Welcome_Notification_Rate' ) ) {
         const RATING_NOTICE_TIME = 432000; // 5 * 24 * 60 * 60
 
         function __construct() {
-            add_action( 'admin_menu', array( $this, 'check_activation_date' ), 9 );
+            if ( is_admin() ) {
+                add_action( 'admin_menu', array( $this, 'check_activation_date' ), 9 );
+            }
         }
 
         /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Premium and rating notifications now appear only within the admin dashboard, preventing any unintended display on the front end.
* **Performance**
  * Reduced front-end overhead by avoiding registration of admin-only hooks outside the admin area, improving page load efficiency for visitors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->