### PR TITLE
fix (design library): remove from inserter

### DIFF
--- a/src/block/design-library/index.js
+++ b/src/block/design-library/index.js
@@ -13,8 +13,6 @@ import edit from './edit'
 import save from './save'
 import metadata from './block.json'
 
-import { addFilter } from '@wordpress/hooks'
-
 export const settings = {
 	...metadata,
 	icon: StackableIcon,
@@ -26,6 +24,7 @@ export const settings = {
 	},
 	supports: {
 		stkSaveBlockStyle: false,
+		inserter: false, // Always hide design library from block inserter
 	},
 	example: {
 		attributes: {
@@ -35,14 +34,3 @@ export const settings = {
 	edit,
 	save,
 }
-
-// Always hide design library from block inserter
-addFilter( `stackable.design-library.settings`, `stackable/design-library/inserter`, settings => {
-	return {
-		...settings,
-		supports: {
-			...settings.supports,
-			inserter: false,
-		},
-	}
-} )

--- a/src/block/design-library/index.js
+++ b/src/block/design-library/index.js
@@ -13,6 +13,8 @@ import edit from './edit'
 import save from './save'
 import metadata from './block.json'
 
+import { addFilter } from '@wordpress/hooks'
+
 export const settings = {
 	...metadata,
 	icon: StackableIcon,
@@ -33,3 +35,14 @@ export const settings = {
 	edit,
 	save,
 }
+
+// Always hide design library from block inserter
+addFilter( `stackable.design-library.settings`, `stackable/design-library/inserter`, settings => {
+	return {
+		...settings,
+		supports: {
+			...settings.supports,
+			inserter: false,
+		},
+	}
+} )

--- a/src/disabled-blocks.js
+++ b/src/disabled-blocks.js
@@ -97,7 +97,10 @@ const applySettingsToMeta = metadata => {
 	if ( typeof metadata.supports === 'undefined' ) {
 		metadata.supports = {}
 	}
-	metadata.supports.inserter = inserter
+
+	if ( typeof metadata.supports.inserter === 'undefined' ) {
+		metadata.supports.inserter = inserter
+	}
 
 	return metadata
 }


### PR DESCRIPTION
fixes #3581 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve existing block visibility settings when applying metadata, avoiding accidental overrides of inserter visibility.
* **Chores**
  * Hide the Design Library block from the inserter by default so it cannot be added directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->