### PR TITLE
fix (design library): change to question mark

### DIFF
--- a/src/components/design-library-list/design-library-list-item.js
+++ b/src/components/design-library-list/design-library-list-item.js
@@ -135,7 +135,7 @@ const DesignLibraryListItem = forwardRef( ( props, ref ) => {
 				<div>
 					{ selectedNum !== 0 &&
 						<Tooltip text={ __( 'Style options are locked for this design because it is selected.', i18n ) }>
-							<Dashicon icon="lock" size={ 16 } />
+							<Dashicon icon="editor-help" size={ 16 } />
 						</Tooltip>
 					}
 					{ selectedTab === 'patterns' ? <span className="stk-block-design__selected-num">{ selectedNum === 0 ? '' : selectedNum }</span>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the tooltip icon shown when items are selected from a lock to a help icon, providing a clearer visual cue.
  - Retains existing tooltip text and selection behavior; only the iconography has changed.
  - Improves clarity without altering workflows or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->