### PR TITLE
fix (design library): hide disabled insert button except for the selected design

### DIFF
--- a/src/components/design-library-list/design-library-list-item.js
+++ b/src/components/design-library-list/design-library-list-item.js
@@ -152,9 +152,8 @@ const DesignLibraryListItem = memo( props => {
 						: <div>
 							<Button
 								label={ __( 'Insert', i18n ) }
-								className="ugb-modal-design-library__add-multi"
+								className={ `ugb-modal-design-library__add-multi ${ selected ? 'stk--is-selected' : '' }` }
 								disabled={ isMultiSelectBusy }
-								data-selected={ selected }
 								onClick={ () => {
 									setSelected( true )
 									onClickDesign()

--- a/src/components/design-library-list/design-library-list-item.js
+++ b/src/components/design-library-list/design-library-list-item.js
@@ -45,6 +45,7 @@ const DesignLibraryListItem = memo( props => {
 	const { hostRef, shadowRoot } = useShadowRoot( shouldRender )
 
 	const ref = useRef( null )
+	const insertButtonRef = useRef( null )
 
 	const {
 		blocks, enableBackground,
@@ -150,10 +151,16 @@ const DesignLibraryListItem = memo( props => {
 					{ selectedTab === 'patterns' ? <span className="stk-block-design__selected-num">{ selectedNum === 0 ? '' : selectedNum }</span>
 						: <div>
 							<Button
+								ref={ insertButtonRef }
 								label={ __( 'Insert', i18n ) }
 								className="ugb-modal-design-library__add-multi"
 								disabled={ isMultiSelectBusy }
-								onClick={ () => onClickDesign() }
+								onClick={ () => {
+									if ( insertButtonRef.current ) {
+										insertButtonRef.current.style.opacity = 1
+									}
+									onClickDesign()
+								} }
 							>
 								{ __( 'Insert', i18n ) }
 								{ isMultiSelectBusy && <Spinner /> }

--- a/src/components/design-library-list/design-library-list-item.js
+++ b/src/components/design-library-list/design-library-list-item.js
@@ -41,11 +41,11 @@ const DesignLibraryListItem = memo( props => {
 		: 120
 
 	const [ isLoading, setIsLoading ] = useState( true )
+	const [ selected, setSelected ] = useState( false )
 
 	const { hostRef, shadowRoot } = useShadowRoot( shouldRender )
 
 	const ref = useRef( null )
-	const insertButtonRef = useRef( null )
 
 	const {
 		blocks, enableBackground,
@@ -151,14 +151,12 @@ const DesignLibraryListItem = memo( props => {
 					{ selectedTab === 'patterns' ? <span className="stk-block-design__selected-num">{ selectedNum === 0 ? '' : selectedNum }</span>
 						: <div>
 							<Button
-								ref={ insertButtonRef }
 								label={ __( 'Insert', i18n ) }
 								className="ugb-modal-design-library__add-multi"
 								disabled={ isMultiSelectBusy }
+								data-selected={ selected }
 								onClick={ () => {
-									if ( insertButtonRef.current ) {
-										insertButtonRef.current.style.opacity = 1
-									}
+									setSelected( true )
 									onClickDesign()
 								} }
 							>

--- a/src/components/design-library-list/editor.scss
+++ b/src/components/design-library-list/editor.scss
@@ -50,6 +50,9 @@
 		@media (hover: none) {
 			opacity: 1;
 		}
+		&[data-selected="true"] {
+			opacity: 1;
+		}
 	}
 	&:hover {
 		// box-shadow: rgba(0, 0, 0, 0.25) 0px 25px 50px -12px;

--- a/src/components/design-library-list/editor.scss
+++ b/src/components/design-library-list/editor.scss
@@ -50,7 +50,7 @@
 		@media (hover: none) {
 			opacity: 1;
 		}
-		&[data-selected="true"] {
+		&.stk--is-selected {
 			opacity: 1;
 		}
 	}

--- a/src/components/modal-design-library/editor.scss
+++ b/src/components/modal-design-library/editor.scss
@@ -174,7 +174,7 @@
 		text-transform: uppercase;
 		&[disabled] {
 			background: #efefef;
-			opacity: 1;
+			// opacity: 1;
 		}
 		&:not([disabled]) {
 			background: linear-gradient(131.34deg, #ee006b -0.77%, #b300be 94.57%);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Insert button now visually reflects selection when clicked, remaining visibly selected.

* **Style**
  * Selected library items render at full opacity so chosen items appear distinct.
  * Disabled “Add” button in the design library modal no longer forces full opacity, making the disabled state visually clearer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->