### PR TITLE
fix: change into transformOrigin to correct attribute name

### DIFF
--- a/src/block-components/transform/attributes.js
+++ b/src/block-components/transform/attributes.js
@@ -5,7 +5,7 @@ export const addAttributes = attrObject => {
 				type: 'number',
 				default: '',
 			},
-			transitionOrigin: {
+			transformOrigin: {
 				type: 'string',
 				default: '',
 			},


### PR DESCRIPTION
fixes #3608 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Refactor
  - Renamed the “Transition Origin” setting to “Transform Origin” in transform controls for clearer terminology. Existing behavior and defaults remain unchanged.

- Style
  - Updated naming to align with expected transform terminology in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->