### PR TITLE
fix: use margin for the alignment of native image block

### DIFF
--- a/src/block/column/editor.scss
+++ b/src/block/column/editor.scss
@@ -54,3 +54,19 @@
 .wp-block-stackable-column {
 	min-width: 0;
 }
+
+/**
+* Add support for native image block alignment inside inner column
+* using margin, since it uses display: block in the editor.
+*
+* @see https://github.com/gambitph/Stackable/issues/3610
+*/
+.wp-block-stackable-column .wp-block-image {
+	.components-resizable-box__container {
+		&,
+		img {
+			margin-left: var(--stk-alignment-margin-left, auto);
+			margin-right: var(--stk-alignment-margin-right, auto);
+		}
+	}
+}


### PR DESCRIPTION
fixes #3610 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrects image alignment inside Stackable columns in the editor. Left- and right-aligned images now display with appropriate side margins, including within resizable containers, preventing awkward block-level spacing.

* **Style**
  * Updates editor styling for images within columns to ensure consistent spacing and alignment. Improves visual consistency when placing images inside inner columns without affecting front-end display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->