### PR TITLE
fix (icon list): display icons on latest Chromium-based browsers

### DIFF
--- a/src/block/icon-list/style.scss
+++ b/src/block/icon-list/style.scss
@@ -70,6 +70,10 @@
 			line-height: 0;
 		}
 	}
+
+	> svg [id^="stk-icon-list__icon-svg-def"] svg {
+		width: initial;
+	}
 }
 
 // Alignments when the icon list is aligned.


### PR DESCRIPTION
fixes #3613 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent icon sizes in icon lists by preventing nested SVGs from inheriting unintended widths, ensuring correct display across devices, themes, and breakpoints. Improves alignment and prevents clipping or unexpected scaling.

* **Style**
  * Standardized icon rendering within icon lists for a more consistent visual appearance and layout stability. No functional changes, settings adjustments, or performance impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->