### PR TITLE
fix: use wp_kses_post instead of esc_html to allow dynamic content

### DIFF
--- a/src/block/posts/index.php
+++ b/src/block/posts/index.php
@@ -132,7 +132,7 @@ if ( ! function_exists( 'generate_render_item_from_stackable_posts_block' ) ) {
 
 		// Read More Link.
 		if ( strpos( $new_template, '!#readmoreText!#' ) !== false ) {
-			$new_template = str_replace( '!#readmoreText!#', esc_html( $readmore_text ), $new_template );
+			$new_template = str_replace( '!#readmoreText!#', wp_kses_post( $readmore_text ), $new_template );
 		}
 
 		return $new_template;


### PR DESCRIPTION
fixes #3618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - “Read More” text in stackable post items now supports basic HTML formatting (e.g., links, bold, italics). This allows richer customization of the link text while maintaining content safety through sanitization. Existing plain-text configurations continue to work without changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->