### PR TITLE
fix: check if Stackable constants are defined

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -26,7 +26,8 @@ if ( ! function_exists( 'stackable_multiple_plugins_check' ) ) {
 	}
 }
 
-if ( defined('STACKABLE_FILE') && STACKABLE_FILE !== __FILE__ && ! isset( $GLOBALS['OTHER_STACKABLE_FILE'] ) ) {
+if ( defined('STACKABLE_FILE') && STACKABLE_FILE !== __FILE__ && ! isset( $GLOBALS['OTHER_STACKABLE_FILE'] ) &&
+	defined( 'STACKABLE_BUILD' ) && defined( 'STACKABLE_VERSION' ) ) {
 	// Get relative file path of the other Stackable version.
 	$GLOBALS['OTHER_STACKABLE_FILE'] = plugin_basename( STACKABLE_FILE );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved detection of parallel installations to prevent duplicate loading and unexpected overrides, reducing activation and update errors.
  - Strengthened version checks so the plugin initializes only when appropriate, enhancing stability in environments with multiple copies.
  - Results in fewer conflicts and clearer behavior when multiple editions or builds are present, with no changes to existing workflows or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->