### PR TITLE
fix (design library): re-render preview of selected pattern when changing categories

### DIFF
--- a/src/components/design-library-list/use-preview-renderer.js
+++ b/src/components/design-library-list/use-preview-renderer.js
@@ -64,6 +64,7 @@ export const usePreviewRenderer = (
 	const shadowBodySizeRef = useRef( null )
 	const prevEnableBackgroundRef = useRef( null )
 	const prevSelectedTabRef = useRef( selectedTab )
+	const prevSelectedNumRef = useRef( selectedNum )
 	const adjustAnimateFrameRef = useRef( null )
 	const renderedTemplate = useRef( false )
 
@@ -304,12 +305,31 @@ export const usePreviewRenderer = (
 		prevSelectedTabRef.current = selectedTab
 	}, [ selectedTab ] )
 
+	// Handles rendering of preview for selected patterns when category or tab changes.
 	useEffect( () => {
-		if ( ! shouldRender ) {
+		if ( ! shouldRender || ! content || ! shadowRoot ) {
 			return
 		}
 
-		if ( ! content || ! shadowRoot ) {
+		// Prevent unnecessary re-renders when the selection state transitions:
+		// - If changing from unselected (0) to selected (number), or currently unselected, just update the ref.
+		// - If changing from selected to unselected, re-rendering is handled in a separate effect to avoid duplicate renders here.
+		if ( ( ! prevSelectedNumRef.current && prevSelectedNumRef.current !== selectedNum ) || ! selectedNum ) {
+			prevSelectedNumRef.current = selectedNum
+			return
+		}
+
+		prevSelectedNumRef.current = selectedNum
+
+		if ( content ) {
+			renderPreview()
+		}
+	}, [ selectedNum, shadowRoot ] )
+
+	// Effect for handling preview re-render and scale adjustment
+	// when content, color schemes, or selection state changes (e.g., toggling from selected to unselected).
+	useEffect( () => {
+		if ( ! shouldRender || ! content || ! shadowRoot ) {
 			return
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate preview renders, reducing flicker when switching tabs or selections.
  * Ensures preview scaling updates at the right time for consistent sizing.
  * Improves handling of theme changes, keeping previews in sync with color scheme updates.

* **Refactor**
  * Streamlines the preview rendering flow to avoid unnecessary work, improving responsiveness and stability when navigating categories, tabs, and selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->