### PR TITLE
fix (carousel block): display layout correctly for content width wide

### DIFF
--- a/src/styles/block.scss
+++ b/src/styles/block.scss
@@ -67,6 +67,8 @@
 }
 @include desktop-tablet {
 	.stk-block:is(.aligncenter, .alignwide, .alignfull) > .stk-content-align.alignwide,
+	// Dev note: add selector for carousel because it has an extra wrapper before the inner blocks.
+	.stk-block-carousel:is(.aligncenter, .alignwide, .alignfull) > :where(.stk-block-carousel__content-wrapper) > .stk-content-align.alignwide,
 	.stk-block .stk-block.alignwide {
 		// --stk-block-default-width is a Stackable setting
 		// --stk-block-width-default-detected is from the fallback autodetected value.

--- a/src/styles/editor-block.scss
+++ b/src/styles/editor-block.scss
@@ -113,7 +113,8 @@
 }
 
 :where(:is(.stk-preview-device-desktop, .stk-preview-device-tablet) [data-type^="stackable/"]:is([data-align="wide"], [data-align="full"]) > .stk-block > .stk-inner-blocks.alignwide),
-:where(:is(.stk-preview-device-desktop, .stk-preview-device-tablet) [data-type^="stackable/"]:is([data-align="wide"], [data-align="full"]) [data-type^="stackable/"][data-align="wide"]) {
+:where(:is(.stk-preview-device-desktop, .stk-preview-device-tablet) [data-type^="stackable/"]:is([data-align="wide"], [data-align="full"]) [data-type^="stackable/"][data-align="wide"]),
+:where(:is(.stk-preview-device-desktop, .stk-preview-device-tablet) [data-type^="stackable/"]:is([data-align="wide"], [data-align="full"]) > .stk-block-carousel > :where(.stk-block-carousel__content-wrapper) > .stk-inner-blocks.alignwide) {
 	// --stk-block-default-width is a Stackable setting
 	// --stk-block-width-default-detected is from the fallback autodetected value.
 	max-width: var(--stk-block-wide-width, var(--stk-block-width-wide-detected, calc(80vw - 280px))) !important; // Make way for the inspector


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrects alignment for carousel blocks on desktop and tablet, ensuring center, wide, and full options render consistently.
  * Ensures wide-aligned content inside carousels respects the expected max-width in the editor.

* **Style**
  * Harmonizes layout handling for carousel wrappers with non-carousel blocks for a more consistent appearance across views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->