### PR TITLE
fix: show blocksy theme styles in the design library

### DIFF
--- a/src/compatibility/blocksy/index.php
+++ b/src/compatibility/blocksy/index.php
@@ -155,8 +155,6 @@ if ( ! function_exists( 'stackable_blocksy_theme_global_styles' ) ) {
 			$styles_from_files = '';
 			foreach ( $blocksy_static_files as $file ) {
 				if ( isset( $file['url'] ) ) {
-					$file_path = get_template_directory() . $file['url'];
-
 					// Normalize and validate the path to prevent traversal
 					$file_url = ltrim( $file['url'], '/' );
 					$file_path = get_template_directory() . '/' . $file_url;

--- a/src/compatibility/blocksy/index.php
+++ b/src/compatibility/blocksy/index.php
@@ -179,12 +179,14 @@ if ( ! function_exists( 'stackable_blocksy_theme_global_styles' ) ) {
 					}
 				}
 			}
+
+			if ( $styles_from_files ) {
+				// sanitize styles from files
+				$styles_from_files = stackable_sanitize_css_string( $styles_from_files );
+				$styles .= $styles_from_files;
+			}
 		}
 
-		// sanitize styles from files
-		$styles_from_files = stackable_sanitize_css_string( $styles_from_files );
-
-		$styles .= $styles_from_files;
 		return $styles;
 	}
 

--- a/src/compatibility/blocksy/index.php
+++ b/src/compatibility/blocksy/index.php
@@ -100,8 +100,18 @@ if ( ! function_exists( 'stackable_blocksy_theme_global_styles' ) ) {
 		$css = preg_replace('/\bexpression\s*\([^)]*\)/i', '', $css);
 		$css = preg_replace('/\bjavascript\s*:/i', '', $css);
 
-		// clean urls
-		$css = preg_replace('/url\(\s*[\'"]?\s*https?:\/\/[^\'")]+\s*[\'"]?\s*\)/i', 'url("")', $css);
+		// Only allow URLs from the theme directory
+		$theme_uri = preg_quote( get_template_directory_uri(), '/' );
+		$css = preg_replace_callback(
+			'/url\(\s*[\'"]?\s*(https?:\/\/[^\'")]+)\s*[\'"]?\s*\)/i',
+			function( $matches ) use ( $theme_uri ) {
+				if ( preg_match( "/^{$theme_uri}/i", $matches[1] ) ) {
+					return $matches[0]; // Keep theme URLs
+				}
+				return 'url("")'; // Remove others
+			},
+			$css
+		);
 
 		// Block unsafe tokens
 		$css = preg_replace('/\b(?:eval|mocha)\b(\s*:|\s*\()/i', '/* blocked */$1', $css);
@@ -145,10 +155,28 @@ if ( ! function_exists( 'stackable_blocksy_theme_global_styles' ) ) {
 			foreach ( $blocksy_static_files as $file ) {
 				if ( isset( $file['url'] ) ) {
 					$file_path = get_template_directory() . $file['url'];
-					$mime = mime_content_type( $file_path );
-					$is_valid_mime = $mime === 'text/css' || $mime === 'text/plain';
-					if ( file_exists( $file_path ) && is_readable( $file_path ) && $is_valid_mime ) {
-						$styles .= file_get_contents( $file_path );
+
+					// Normalize and validate the path to prevent traversal
+					$file_url = ltrim( $file['url'], '/' );
+					$file_path = get_template_directory() . '/' . $file_url;
+					$file_path = realpath( $file_path );
+					$theme_dir = realpath( get_template_directory() );
+
+					// Ensure the resolved path is within the theme directory
+					if ( ! $file_path || strpos( $file_path, $theme_dir ) !== 0 ) {
+						continue;
+					}
+
+					if ( file_exists( $file_path ) && is_readable( $file_path ) ) {
+						$extension = strtolower( pathinfo( $file_path, PATHINFO_EXTENSION ) );
+						if ( $extension !== 'css' ) {
+							continue;
+						}
+						$content = file_get_contents( $file_path );
+						if ( $content !== false ) {
+							$styles .= $content;
+						}
+
 					}
 				}
 			}

--- a/src/compatibility/blocksy/index.php
+++ b/src/compatibility/blocksy/index.php
@@ -112,10 +112,11 @@ if ( ! function_exists( 'stackable_blocksy_theme_global_styles' ) ) {
 
 			foreach ( $blocksy_static_files as $file ) {
 				if ( isset( $file['url'] ) ) {
-					$file_url = get_template_directory_uri() . $file['url'];
-					$response = wp_remote_get( $file_url );
-					if ( ! is_wp_error( $response ) ) {
-						$styles .= wp_remote_retrieve_body( $response );
+					$file_path = get_template_directory() . $file['url'];
+					$mime = mime_content_type( $file_path );
+					$is_valid_mime = $mime === 'text/css' || $mime === 'text/plain';
+					if ( file_exists( $file_path ) && is_readable( $file_path ) && $is_valid_mime ) {
+						$styles .= file_get_contents( $file_path );
 					}
 				}
 			}

--- a/src/compatibility/blocksy/index.php
+++ b/src/compatibility/blocksy/index.php
@@ -90,6 +90,38 @@ if ( ! function_exists( 'stackable_blocksy_global_color_schemes_compatibility' )
 }
 
 if ( ! function_exists( 'stackable_blocksy_theme_global_styles' ) ) {
+	function stackable_sanitize_css_string( $css ) {
+		if ( ! is_string( $css ) ) {
+			return '';
+		}
+
+		// sanitize css content
+		$css = wp_strip_all_tags( $css );
+		$css = preg_replace('/\bexpression\s*\([^)]*\)/i', '', $css);
+		$css = preg_replace('/\bjavascript\s*:/i', '', $css);
+
+		// clean urls
+		$css = preg_replace('/url\(\s*[\'"]?\s*https?:\/\/[^\'")]+\s*[\'"]?\s*\)/i', 'url("")', $css);
+
+		// Block unsafe tokens
+		$css = preg_replace('/\b(?:eval|mocha)\b(\s*:|\s*\()/i', '/* blocked */$1', $css);
+
+		// Block behavior and vendor-prefixed behavior
+		$css = preg_replace('/(?<![a-zA-Z0-9-])(?:-+[a-zA-Z]*behavior|behavior)\b(\s*:|\s*\()/i', '/* blocked */$1', $css);
+
+		// Remove redundant semicolons
+		$css = preg_replace('/;+/', ';', $css);
+
+		// Remove empty rule blocks (e.g. ".selector { }")
+		$css = preg_replace('/[^{]+\{\s*\}/m', '', $css);
+
+		// Normalize spacing and line breaks
+		$css = preg_replace('/\s+/', ' ', $css);
+		$css = trim($css);
+
+		return $css;
+	}
+
 	function stackable_blocksy_theme_global_styles( $styles ) {
 
 		if ( function_exists( 'blocksy_manager' ) ) {
@@ -122,6 +154,8 @@ if ( ! function_exists( 'stackable_blocksy_theme_global_styles' ) ) {
 			}
 		}
 
+		// sanitize all added styles once
+		$styles = stackable_sanitize_css_string( $styles );
 		return $styles;
 	}
 

--- a/src/compatibility/blocksy/index.php
+++ b/src/compatibility/blocksy/index.php
@@ -88,3 +88,41 @@ if ( ! function_exists( 'stackable_blocksy_global_color_schemes_compatibility' )
 
 	add_filter( 'stackable.global-settings.global-color-schemes.add-theme-compatibility', 'stackable_blocksy_global_color_schemes_compatibility', 10, 6 );
 }
+
+if ( ! function_exists( 'stackable_blocksy_theme_global_styles' ) ) {
+	function stackable_blocksy_theme_global_styles( $styles ) {
+
+		if ( function_exists( 'blocksy_manager' ) ) {
+			$blocksy_css = blocksy_manager()->dynamic_css->load_backend_dynamic_css([
+				'echo' => false
+			] );
+
+			$styles .= $blocksy_css;
+		}
+
+		if ( class_exists( 'Blocksy_Static_Css_Files' ) ) {
+			$blocksy_static_files = ( new Blocksy_Static_Css_Files() )->all_static_files();
+
+			$blocksy_static_files = array_filter(
+				$blocksy_static_files,
+				function( $file ) {
+					return isset( $file['id'] ) && in_array( $file['id'], array( 'ct-main-styles', 'ct-stackable-styles' ), true );
+				}
+			);
+
+			foreach ( $blocksy_static_files as $file ) {
+				if ( isset( $file['url'] ) ) {
+					$file_url = get_template_directory_uri() . $file['url'];
+					$response = wp_remote_get( $file_url );
+					if ( ! is_wp_error( $response ) ) {
+						$styles .= wp_remote_retrieve_body( $response );
+					}
+				}
+			}
+		}
+
+		return $styles;
+	}
+
+	add_filter( 'stackable.design-library.global-theme-styles', 'stackable_blocksy_theme_global_styles' );
+}

--- a/src/compatibility/blocksy/index.php
+++ b/src/compatibility/blocksy/index.php
@@ -152,6 +152,7 @@ if ( ! function_exists( 'stackable_blocksy_theme_global_styles' ) ) {
 				}
 			);
 
+			$styles_from_files = '';
 			foreach ( $blocksy_static_files as $file ) {
 				if ( isset( $file['url'] ) ) {
 					$file_path = get_template_directory() . $file['url'];
@@ -174,7 +175,7 @@ if ( ! function_exists( 'stackable_blocksy_theme_global_styles' ) ) {
 						}
 						$content = file_get_contents( $file_path );
 						if ( $content !== false ) {
-							$styles .= $content;
+							$styles_from_files .= $content;
 						}
 
 					}
@@ -182,8 +183,10 @@ if ( ! function_exists( 'stackable_blocksy_theme_global_styles' ) ) {
 			}
 		}
 
-		// sanitize all added styles once
-		$styles = stackable_sanitize_css_string( $styles );
+		// sanitize styles from files
+		$styles_from_files = stackable_sanitize_css_string( $styles_from_files );
+
+		$styles .= $styles_from_files;
 		return $styles;
 	}
 

--- a/src/compatibility/blocksy/style.scss
+++ b/src/compatibility/blocksy/style.scss
@@ -3,6 +3,7 @@
 :where(.stk--is-blocksy-theme.stk--has-default-container-scheme) {
 	--stk-default-link-color: var(--theme-link-initial-color);
 	--stk-default-heading-color: var(--theme-heading-color, var(--theme-headings-color));
+	--stk-default-button-background-color: var(--theme-button-background-initial-color);
 
 	:where(.stk-block-heading) {
 		@for $i from 1 through 6 {

--- a/src/compatibility/index.php
+++ b/src/compatibility/index.php
@@ -8,3 +8,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 require_once( plugin_dir_path( __FILE__ ) . './neve/index.php' );
 require_once( plugin_dir_path( __FILE__ ) . './ewww.php' );
 require_once( plugin_dir_path( __FILE__ ) . './woocommerce.php' );
+require_once( plugin_dir_path( __FILE__ ) . './blocksy/index.php' );

--- a/src/design-library/init.php
+++ b/src/design-library/init.php
@@ -30,6 +30,8 @@ if ( ! class_exists( 'Stackable_Design_Library' ) ) {
 			add_action( 'rest_api_init', array( $this, 'register_route' ) );
 
 			add_action( 'stackable_delete_design_library_cache', array( $this, 'delete_cache_v3' ) );
+
+			add_filter( 'stackable_localize_script', array( $this, 'add_wp_theme_global_styles' ) );
 		}
 
 		public static function validate_string( $value, $request, $param ) {
@@ -298,6 +300,16 @@ if ( ! class_exists( 'Stackable_Design_Library' ) ) {
 		 */
 		public static function get_cdn_url() {
 			return trailingslashit( STACKABLE_DESIGN_LIBRARY_URL );
+		}
+
+		public function add_wp_theme_global_styles( $args ) {
+			$wp_global_styles = apply_filters( 'stackable.design-library.global-theme-styles', '' );
+
+			$wp_global_styles .= wp_get_global_stylesheet();
+
+			$args['wpGlobalStylesInlineCss'] = $wp_global_styles;
+
+			return $args;
 		}
 	}
 

--- a/src/init.php
+++ b/src/init.php
@@ -334,8 +334,6 @@ if ( ! class_exists( 'Stackable_Init' ) ) {
 
 			$version_parts = explode( '-', STACKABLE_VERSION );
 
-			$wp_global_styles = wp_get_global_stylesheet();
-
 			global $content_width;
 			global $wp_version;
 			$args = apply_filters( 'stackable_localize_script', array(
@@ -373,9 +371,6 @@ if ( ! class_exists( 'Stackable_Init' ) ) {
 				'settings' => apply_filters( 'stackable_js_settings', array() ),
 				'isContentOnlyMode' => apply_filters( 'stackable_editor_role_is_content_only', false ),
 				'blockCategoryIndex' => apply_filters( 'stackable_block_category_index', 0 ),
-
-				// Global Styles for Design Library
-				'wpGlobalStylesInlineCss' => $wp_global_styles,
 			) );
 			wp_localize_script( 'wp-blocks', 'stackable', $args );
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blocksy theme styles (dynamic and static) are now collected and appended to the design library’s global styles and delivered during initialization.

* **Style**
  * Added a default button background color to align buttons with theme colors.

* **Bug Fixes / Reliability**
  * Aggregated theme CSS is validated and sanitized before use to prevent unsafe or invalid CSS.

* **Chores**
  * Removed prior inlined global stylesheet delivery in editor assets and consolidated delivery via the design library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->