### PR TITLE
fix (posts block): fix image width in horizontal block styles

### DIFF
--- a/src/block/posts/style.js
+++ b/src/block/posts/style.js
@@ -281,26 +281,13 @@ Image.addStyles( blockStyles, {
 		const blockStyle = getBlockStyle( variations, className )
 		return ! [ 'list', 'horizontal', 'horizontal-2', 'portfolio', 'portfolio-2', 'vertical-card-2' ].includes( blockStyle?.name )
 	},
-	saveEnableWidthCallback: getAttribute => {
-		const className = getAttribute( 'className' )
-		const imageHasLink = getAttribute( 'imageHasLink' )
-		const blockStyle = getBlockStyle( variations, className )
-
-		if ( [ 'horizontal', 'horizontal-2' ].includes( blockStyle?.name ) ) {
-			if ( imageHasLink ) {
-				return false
-			}
-			return true
-		}
-		return true
-	},
 	selectorCallback: ( getAttribute, _attributes, _clientId, props ) => {
 		const className = getAttribute( 'className' )
 		const blockStyle = getBlockStyle( variations, className )
 		const imageHasLink = getAttribute( 'imageHasLink' )
 
 		const selector = props.selector
-		if ( [ 'list' ].includes( blockStyle?.name ) && imageHasLink ) {
+		if ( [ 'list', 'horizontal', 'horizontal-2' ].includes( blockStyle?.name ) && imageHasLink ) {
 			return Array.isArray( selector )
 				? [ ...selector, `${ itemSelector } .stk-block-posts__image-link` ]
 				: [ selector, `${ itemSelector } .stk-block-posts__image-link` ]
@@ -312,7 +299,7 @@ Image.addStyles( blockStyles, {
 		const blockStyle = getBlockStyle( variations, className )
 		const imageHasLink = getAttribute( 'imageHasLink' )
 
-		if ( [ 'list' ].includes( blockStyle?.name ) && imageHasLink ) {
+		if ( [ 'list', 'horizontal', 'horizontal-2' ].includes( blockStyle?.name ) && imageHasLink ) {
 			return 'flexBasis'
 		}
 		return 'width'

--- a/src/block/posts/style.js
+++ b/src/block/posts/style.js
@@ -288,7 +288,7 @@ Image.addStyles( blockStyles, {
 
 		if ( [ 'horizontal', 'horizontal-2' ].includes( blockStyle?.name ) ) {
 			// If the image has a link and the width unit is %, return false
-			// because the we have set a custom selector for the image width that uses the % unit.
+			// because we have set a custom selector for the image width that uses the % unit.
 			if ( imageHasLink && ( getAttribute( 'imageWidthUnit' ) === '%' ||
 			getAttribute( 'imageWidthUnitTablet' ) === '%' ) ) {
 				return false

--- a/src/block/posts/style.js
+++ b/src/block/posts/style.js
@@ -281,13 +281,29 @@ Image.addStyles( blockStyles, {
 		const blockStyle = getBlockStyle( variations, className )
 		return ! [ 'list', 'horizontal', 'horizontal-2', 'portfolio', 'portfolio-2', 'vertical-card-2' ].includes( blockStyle?.name )
 	},
+	saveEnableWidthCallback: getAttribute => {
+		const className = getAttribute( 'className' )
+		const imageHasLink = getAttribute( 'imageHasLink' )
+		const blockStyle = getBlockStyle( variations, className )
+
+		if ( [ 'horizontal', 'horizontal-2' ].includes( blockStyle?.name ) ) {
+			// If the image has a link and the width unit is %, return false
+			// because the we have set a custom selector for the image width that uses the % unit.
+			if ( imageHasLink && ( getAttribute( 'imageWidthUnit' ) === '%' ||
+			getAttribute( 'imageWidthUnitTablet' ) === '%' ) ) {
+				return false
+			}
+			return true
+		}
+		return true
+	},
 	selectorCallback: ( getAttribute, _attributes, _clientId, props ) => {
 		const className = getAttribute( 'className' )
 		const blockStyle = getBlockStyle( variations, className )
 		const imageHasLink = getAttribute( 'imageHasLink' )
 
 		const selector = props.selector
-		if ( [ 'list', 'horizontal', 'horizontal-2' ].includes( blockStyle?.name ) && imageHasLink ) {
+		if ( [ 'list' ].includes( blockStyle?.name ) && imageHasLink ) {
 			return Array.isArray( selector )
 				? [ ...selector, `${ itemSelector } .stk-block-posts__image-link` ]
 				: [ selector, `${ itemSelector } .stk-block-posts__image-link` ]
@@ -299,7 +315,7 @@ Image.addStyles( blockStyles, {
 		const blockStyle = getBlockStyle( variations, className )
 		const imageHasLink = getAttribute( 'imageHasLink' )
 
-		if ( [ 'list', 'horizontal', 'horizontal-2' ].includes( blockStyle?.name ) && imageHasLink ) {
+		if ( [ 'list' ].includes( blockStyle?.name ) && imageHasLink ) {
 			return 'flexBasis'
 		}
 		return 'width'


### PR DESCRIPTION
fixes #3554 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image sizing in horizontal and list post layouts: linked images that use percentage-based widths now preserve their intended display and sizing, avoiding incorrect width reduction and delivering more consistent visuals across layout modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->