### PR TITLE
fix: skip the first render so the anchor auto-generation only happens…

### DIFF
--- a/src/block/heading/edit.js
+++ b/src/block/heading/edit.js
@@ -105,6 +105,12 @@ const Edit = props => {
 	const updateTimeout = useRef( null )
 
 	useEffect( () => {
+		// Use updateTimeout to skip effect on first render
+		if ( updateTimeout.current === null ) {
+			updateTimeout.current = true
+			return
+		}
+
 		clearTimeout( updateTimeout.current )
 		const anchor = props.attributes.anchor
 		const text = props.attributes.text

--- a/src/block/heading/edit.js
+++ b/src/block/heading/edit.js
@@ -103,11 +103,12 @@ const Edit = props => {
 	// Auto-generate anchors in Stackable headings.
 	const [ prevText, setPrevText ] = useState( props.attributes.text )
 	const updateTimeout = useRef( null )
+	const isFirstRender = useRef( true )
 
 	useEffect( () => {
 		// Use updateTimeout to skip effect on first render
-		if ( updateTimeout.current === null ) {
-			updateTimeout.current = true
+		if ( isFirstRender.current ) {
+			isFirstRender.current = false
 			return
 		}
 


### PR DESCRIPTION
… onchange

fixes #3297, #3078

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted heading block processing to skip an unnecessary initial update while preserving debounced updates for subsequent edits, reducing redundant work and improving responsiveness when a heading is first rendered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->