### PR TITLE
fix: display useful plugins tab only if user can install/activate plugins

### DIFF
--- a/src/welcome/index.php
+++ b/src/welcome/index.php
@@ -206,7 +206,7 @@ if ( ! class_exists( 'Stackable_Welcome_Screen' ) ) {
 					</a>
 				<?php } ?>
 
-				<?php if ( current_user_can( 'install_plugins' ) || current_user_can( 'activate_plugins' ) ) { ?>
+				<?php if ( current_user_can( 'install_plugins' ) && current_user_can( 'activate_plugins' ) ) { ?>
 					<a class="s-tab <?php echo $screen->base === 'stackable_page_stackable-useful-plugins' ? 's-active' : '' ?>"
 						href="<?php echo admin_url( 'admin.php?page=stackable-useful-plugins' ) ?>">
 						<span><?php _e( 'Useful Plugins', STACKABLE_I18N ) ?></span>

--- a/src/welcome/index.php
+++ b/src/welcome/index.php
@@ -206,10 +206,12 @@ if ( ! class_exists( 'Stackable_Welcome_Screen' ) ) {
 					</a>
 				<?php } ?>
 
-				<a class="s-tab <?php echo $screen->base === 'stackable_page_stackable-useful-plugins' ? 's-active' : '' ?>"
-					href="<?php echo admin_url( 'admin.php?page=stackable-useful-plugins' ) ?>">
-					<span><?php _e( 'Useful Plugins', STACKABLE_I18N ) ?></span>
-				</a>
+				<?php if ( current_user_can( 'install_plugins' ) || current_user_can( 'activate_plugins' ) ) { ?>
+					<a class="s-tab <?php echo $screen->base === 'stackable_page_stackable-useful-plugins' ? 's-active' : '' ?>"
+						href="<?php echo admin_url( 'admin.php?page=stackable-useful-plugins' ) ?>">
+						<span><?php _e( 'Useful Plugins', STACKABLE_I18N ) ?></span>
+					</a>
+				<?php } ?>
 
 			</div>
 			<?php


### PR DESCRIPTION
fixes #3661 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The "Useful Plugins" tab now only appears to users with permission to install or activate plugins.
  * UI visibility for plugin-related controls has been aligned with user capabilities to prevent unavailable actions from being shown.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->