### PR TITLE
fix: don't show cimo notice if premium

### DIFF
--- a/src/components/image-control2/index.js
+++ b/src/components/image-control2/index.js
@@ -11,7 +11,9 @@ import Button from '../button'
  * External dependencies
  */
 import classnames from 'classnames'
-import { i18n, cimo } from 'stackable'
+import {
+	i18n, cimo, isPro,
+} from 'stackable'
 import {
 	useAttributeName, useBlockAttributesContext, useBlockSetAttributesContext,
 } from '~stackable/hooks'
@@ -88,7 +90,7 @@ const ImageControl = memo( props => {
 
 	useEffect( () => {
 		// Skip displaying the Cimo notice if the plugin is already activated or the user has chosen to hide the notice
-		if ( ! cimo || cimo.hideNotice || cimo.status === 'activated' ) {
+		if ( isPro || ! cimo || cimo.hideNotice || cimo.status === 'activated' ) {
 			return
 		}
 


### PR DESCRIPTION
fixes #3659 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image control notice now correctly respects pro user status and remains hidden.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->