### PR TITLE
fix: colors of page icons not being shown/applied

### DIFF
--- a/src/block-components/icon/index.js
+++ b/src/block-components/icon/index.js
@@ -184,6 +184,8 @@ export const Icon = props => {
 
 	const ShapeComp = useMemo( () => getShapeSVG( getAttribute( 'backgroundShape' ) || 'blob1' ), [ getAttribute( 'backgroundShape' ) ] )
 
+	const iconColorType = getAttribute( 'iconColorType' )
+
 	const _icon = value || getAttribute( 'icon' )
 	const currentIconRef = useRef( _icon )
 	const processedIconRef = useRef( null )
@@ -204,7 +206,14 @@ export const Icon = props => {
 
 		// Don't use page icons for multicolor icons
 		// because we target svg elements with the :nth-of-type() selector to apply the multicolor styles.
-		if ( getAttribute( 'iconColorType' ) === 'multicolor' ) {
+		if ( iconColorType === 'multicolor' ) {
+			// Clean up if this icon was previously in the page-icons store
+			if ( processedIconRef.current === _icon && _icon ) {
+				dispatch( 'stackable/page-icons' ).removePageIcon( _icon )
+				processedIconRef.current = null
+				setIcon( _icon ) // Use the original icon directly
+				lastIconValueRef.current = _icon
+			}
 			return
 		}
 
@@ -288,7 +297,7 @@ export const Icon = props => {
 				lastIconValueRef.current = null
 			}
 		}
-	}, [ _icon ] )
+	}, [ _icon, iconColorType ] )
 
 	useEffect( () => {
 		return () => {

--- a/src/block-components/icon/index.js
+++ b/src/block-components/icon/index.js
@@ -202,6 +202,12 @@ export const Icon = props => {
 			return
 		}
 
+		// Don't use page icons for multicolor icons
+		// because we target svg elements with the :nth-of-type() selector to apply the multicolor styles.
+		if ( getAttribute( 'iconColorType' ) === 'multicolor' ) {
+			return
+		}
+
 		// Check if icon exists in pageIcons Map
 		// The Map structure is: [SVG string (key), { id: iconId, count: number } (value)]
 		if ( _icon ) {

--- a/src/plugins/page-icons/index.js
+++ b/src/plugins/page-icons/index.js
@@ -28,7 +28,8 @@ pageIconsWrapper?.setAttribute( 'id', 'stk-page-icons' )
 domReady( () => {
 	if ( pageIconsWrapper ) {
 		pageIconsWrapper.setAttribute( 'id', 'stk-page-icons' )
-		pageIconsWrapper.setAttribute( 'style', 'display: none;' )
+		// Don't use `display: none` to hide the page icons because it prevents gradients from being applied.
+		pageIconsWrapper.setAttribute( 'style', 'position: absolute; top: 0; left: -9999px; width: 0; height: 0; visibility: hidden;' )
 		createRoot( pageIconsWrapper ).render( <PageIcons /> )
 	}
 } )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stop generating/updating page icons for multicolor icons and clean up any prior page-icon state.

* **Behavior**
  * Page icons now react correctly when an icon's color type changes.

* **Accessibility & Performance**
  * Improved icon hiding technique to be offscreen for better accessibility and rendering performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->