### PR TITLE
fix (posts block): display correct default content order on sort reset

### DIFF
--- a/src/block/posts/edit.js
+++ b/src/block/posts/edit.js
@@ -182,7 +182,7 @@ const Edit = props => {
 				blockState={ props.blockState }
 				contentOrderOptions={ contentOrderOptions }
 				contentOrder={ contentOrder }
-				DefaultContentOrder={ defaultContentOrder }
+				defaultContentOrder={ defaultContentOrder }
 				orderBy={ orderBy }
 				order={ order }
 				type={ type }


### PR DESCRIPTION
fixes #3657 

Note: Vertical 2 Layout doesn't include the featured image in the sort content options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal property naming consistency for better code maintainability. No changes to functionality or user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->