### PR TITLE
Fix: Accordion collapsed state background color not applying correctly

### DIFF
--- a/src/block/accordion/frontend-accordion.js
+++ b/src/block/accordion/frontend-accordion.js
@@ -87,7 +87,7 @@ class StackableAccordion {
 				}
 
 				el.classList[
-					! Array.from( el.classList ).includes( 'stk--is-open' ) ? 'add' : 'remove'
+					el.open ? 'add' : 'remove'
 				]( 'stk--is-open' )
 
 				// When the accordion is triggered to open/close, we animate

--- a/src/components/block-css/index.js
+++ b/src/components/block-css/index.js
@@ -304,11 +304,11 @@ const BlockCss = props => {
 	// TODO: why do we have this condition for the collapsedSelector, but they just do the same prepending??
 	if ( hasCollapsed ) {
 		if ( generateForAllBlockStates ) {
-			collapsedSelector = prependClass( selector, '%h :where(.stk-block-accordion.stk--is-open) .%s' )
+			collapsedSelector = prependClass( selector, '%h :where(.stk-block-accordion:not(.stk--is-open)) .%s' )
 		} else if ( blockState === 'collapsed' ) {
-			collapsedSelector = prependClass( selector, ':where(.stk-block-accordion.stk--is-open) .%s' )
+			collapsedSelector = prependClass( selector, ':where(.stk-block-accordion:not(.stk--is-open)) .%s' )
 		} else {
-			collapsedSelector = prependClass( selector, ':where(.stk-block-accordion.stk--is-open) .%s' )
+			collapsedSelector = prependClass( selector, ':where(.stk-block-accordion:not(.stk--is-open)) .%s' )
 		}
 	}
 


### PR DESCRIPTION
When using different background colors for Normal and Collapsed states on the accordion's inner column, the Collapsed state color was not being applied when the accordion was closed.

**Root Cause:**
1. CSS selector in block-css/index.js was targeting '.stk-block-accordion.stk--is-open' which applied collapsed styles when accordion was OPEN (inverted logic)
2. Frontend class toggle was toggling based on class existence instead of the actual 'open' attribute state

**Fixes:**
1. Changed collapsed CSS selector to ':not(.stk--is-open)' to correctly apply styles when accordion is closed
2. Fixed frontend-accordion.js to add/remove 'stk--is-open' class based on el.open property instead of toggling

**Screenshots:**
<img width="1142" height="310" alt="image" src="https://github.com/user-attachments/assets/f797ed40-f773-4613-97b6-3600b28dca68" />
<img width="1138" height="185" alt="image" src="https://github.com/user-attachments/assets/101155dc-0e1d-41af-8a71-e60b361cdcfb" />


Fixes #3670

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accordion component state management to ensure open and closed states are consistently synchronized and properly reflected in the user interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->