### PR TITLE
feat: add an option to change displayed taxonomy instead of category

### DIFF
--- a/src/block/posts/edit.js
+++ b/src/block/posts/edit.js
@@ -107,6 +107,7 @@ const Edit = props => {
 		taxonomyType = 'category',
 		taxonomy = '',
 		taxonomyFilterType = '__in',
+		taxonomyTypeToDisplay = 'category',
 		contentOrder = DEFAULT_ORDER,
 		uniqueId,
 	} = attributes
@@ -189,6 +190,7 @@ const Edit = props => {
 				taxonomyType={ taxonomyType }
 				taxonomy={ taxonomy }
 				taxonomyFilterType={ taxonomyFilterType }
+				taxonomyTypeToDisplay={ taxonomyTypeToDisplay }
 				blockStyle={ blockStyle }
 				focalPointPlaceholder={ focalPointPlaceholder }
 			/>
@@ -319,6 +321,8 @@ const InspectorControls = memo( props => {
 						onChangeTaxonomy={ taxonomy => props.setAttributes( { taxonomy } ) }
 						taxonomyFilterType={ props.taxonomyFilterType }
 						onChangeTaxonomyFilterType={ taxonomyFilterType => props.setAttributes( { taxonomyFilterType } ) }
+						taxonomyTypeToDisplay={ props.taxonomyTypeToDisplay }
+						onChangeTaxonomyTypeToDisplay={ taxonomyTypeToDisplay => props.setAttributes( { taxonomyTypeToDisplay } ) }
 						stkVersion="3"
 					/>
 					{ showProNotice && <ProControlButton type="posts" /> }

--- a/src/block/posts/index.php
+++ b/src/block/posts/index.php
@@ -67,7 +67,10 @@ if ( ! function_exists( 'generate_render_item_from_stackable_posts_block' ) ) {
 
 		// Category.
 		if ( strpos( $new_template, '!#category!#' ) !== false ) {
-			$category = Stackable_Posts_Block::get_category_list_by_id( $post_id );
+			// If taxonomyTypeToDisplay is set, display that taxonomy instead of category.
+			$taxonomy_type = isset( $attributes['taxonomyTypeToDisplay'] ) ? $attributes['taxonomyTypeToDisplay'] : 'category';
+			$category = Stackable_Posts_Block::get_taxonomy_term_list_by_id( $post_id, $taxonomy_type );
+			
 			if ( $category_highlighted ) {
 				preg_match_all( '/<a href="([^"]*)"[^>]*>([^<]*)<\/a>/', $category, $matches );
 				foreach ( $matches[0] as $i=>$match ) {
@@ -442,14 +445,35 @@ if ( ! class_exists( 'Stackable_Posts_Block' ) ) {
 		}
 
 		/**
-		 * Get the category list by post id
+		 * Get the taxonomy term list by post id
 		 *
-		 * @param string post id
+		 * @param string $post_id
+		 * @param string $taxonomy
 		 *
-		 * @return string the category list
+		 * @return string the taxonomy term list
 		 */
-		public static function get_category_list_by_id( $id ) {
-			return get_the_category_list( esc_html__( ', ', STACKABLE_I18N ), '', $id );
+		public static function get_taxonomy_term_list_by_id( $post_id, $taxonomy ) {
+			if ( $taxonomy === 'category' ) {
+				return get_the_category_list( esc_html__( ', ', STACKABLE_I18N ), '', $post_id );
+			}
+
+			$terms = get_the_terms( $post_id, $taxonomy );
+			
+			if ( is_wp_error( $terms ) || empty( $terms ) ) {
+				return '';
+			}
+			
+			$separator = esc_html__( ', ', STACKABLE_I18N );
+			$term_links = array();
+			
+			foreach ( $terms as $term ) {
+				$term_link = get_term_link( $term, $taxonomy );
+				if ( ! is_wp_error( $term_link ) ) {
+					$term_links[] = '<a href="' . esc_url( $term_link ) . '">' . esc_html( $term->name ) . '</a>';
+				}
+			}
+			
+			return implode( $separator, $term_links );
 		}
 
 		/**
@@ -559,7 +583,11 @@ if ( ! class_exists( 'Stackable_Posts_Block' ) ) {
 
 				$query->posts[$key]->comments_num = $this->get_comments_number( $post_array );
 				$query->posts[$key]->author_info = $this->get_author_info( $post_array );
-				$query->posts[$key]->category_list = $this->get_category_list_by_id( $post->ID );
+				
+				// If taxonomy_type_to_display is set, get terms from that taxonomy instead of category.
+				$taxonomy_type = isset( $args['taxonomy_type_to_display'] ) ? $args['taxonomy_type_to_display'] : 'category';
+				$query->posts[$key]->category_list = $this->get_taxonomy_term_list_by_id( $post->ID, $taxonomy_type );
+
 				$query->posts[$key]->featured_image_urls = $this->get_featured_image_urls_from_attachment_id( get_post_thumbnail_id($post->ID) );
 			}
 

--- a/src/block/posts/schema.js
+++ b/src/block/posts/schema.js
@@ -312,6 +312,17 @@ export const attributes = ( version = VERSION ) => {
 		versionDeprecated: '',
 	} )
 
+	attrObject.add( {
+		attributes: {
+			taxonomyTypeToDisplay: {
+				type: 'string',
+				default: 'category',
+			},
+		},
+		versionAdded: '3.19.8',
+		versionDeprecated: '',
+	} )
+
 	return attrObject.getMerged( version )
 }
 

--- a/src/components/taxonomy-control/index.js
+++ b/src/components/taxonomy-control/index.js
@@ -149,6 +149,7 @@ class TaxonomyControl extends Component {
 							this.props.onChangePostType( value )
 							this.props.onChangeTaxonomyType( taxonomyTypesAvailable.length ? taxonomyTypesAvailable[ 0 ] : '' )
 							this.props.onChangeTaxonomy( '' )
+							this.props.onChangeTaxonomyTypeToDisplay( taxonomyTypesAvailable.length ? taxonomyTypesAvailable[ 0 ] : '' )
 						} }
 						default="post"
 					/>
@@ -193,6 +194,19 @@ class TaxonomyControl extends Component {
 							} }
 						/>
 					</Fragment>
+				}
+				{ taxonomyTypeOptions.length > 0 &&
+					<AdvancedSelectControl
+						label={ __( 'Taxonomy to Display', i18n ) }
+						options={ taxonomyTypeOptions }
+						value={ this.props.taxonomyTypeToDisplay }
+						allowReset={ allowReset }
+						onChange={ value => {
+							this.props.onChangeTaxonomyTypeToDisplay( value )
+						} }
+						default={ taxonomyTypeOptions[ 0 ]?.value || 'category' }
+						help={ __( 'Taxonomy to display instead of Category.', i18n ) }
+					/>
 				}
 			</div>
 		)

--- a/src/hooks/use-posts-query.js
+++ b/src/hooks/use-posts-query.js
@@ -28,6 +28,7 @@ export const usePostsQuery = attributes => {
 		taxonomyType,
 		taxonomy,
 		taxonomyFilterType,
+		taxonomyTypeToDisplay,
 		postOffset,
 		postExclude,
 		postInclude,
@@ -47,6 +48,7 @@ export const usePostsQuery = attributes => {
 				orderby: [ orderBy, 'ID' ].join( ' ' ),
 				posts_per_page: numberOfItems, // eslint-disable-line camelcase
 				max_excerpt: excerptLength, // eslint-disable-line camelcase
+				taxonomy_type_to_display: taxonomyTypeToDisplay, // eslint-disable-line camelcase
 			}, attributes ),
 		}, value => {
 			// Exludes and includes can be empty.
@@ -82,6 +84,7 @@ export const usePostsQuery = attributes => {
 		taxonomyType,
 		taxonomy,
 		taxonomyFilterType,
+		taxonomyTypeToDisplay,
 		postOffset,
 		postExclude,
 		postInclude,


### PR DESCRIPTION
fixes #3678

This is not a bug but a feature request. The selected taxonomy under `Filter by Taxonomy` is used for filtering which post items are displayed. To be able to display custom taxonomy terms instead of `Categories`, we have to add that option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable taxonomy display option to the Posts block. Users can now select which taxonomy type (e.g., categories, tags, or custom taxonomies) to display alongside each post. The block defaults to categories but now supports any available taxonomy, providing greater flexibility in content presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->