### PR TITLE
fix: correct the version number of the deprecation

### DIFF
--- a/src/block/posts/schema.js
+++ b/src/block/posts/schema.js
@@ -319,7 +319,7 @@ export const attributes = ( version = VERSION ) => {
 				default: 'category',
 			},
 		},
-		versionAdded: '3.19.8',
+		versionAdded: '3.19.7',
 		versionDeprecated: '',
 	} )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable taxonomy display option to the posts block, allowing selection of taxonomy types with category as the default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->