### PR TITLE
fix: fix lazy-loaded images in safari

### DIFF
--- a/src/block-components/image/style.scss
+++ b/src/block-components/image/style.scss
@@ -71,7 +71,7 @@
 	}
 }
 
-// This is needed to fix the images rendering as lines when lazy-loaded in Safari.
+// This is needed to fix the images rendering as lines when lazy-loaded in Safari. We target only the known issue here based on lazy loading from another plugin so as not to affect other uses of the image
 // Targets Safari 9+ on iOS and macOS, works as of late 2025.
 @supports (font: -apple-system-body) {
 	img.stk-img.lazyloaded {

--- a/src/block-components/image/style.scss
+++ b/src/block-components/image/style.scss
@@ -74,7 +74,7 @@
 // This is needed to fix the images rendering as lines when lazy-loaded in Safari.
 // Targets Safari 9+ on iOS and macOS, works as of late 2025.
 @supports (font: -apple-system-body) {
-	img.stk-img {
+	img.stk-img.lazyloaded {
 		will-change: transform;
 	}
 }

--- a/src/block-components/image/style.scss
+++ b/src/block-components/image/style.scss
@@ -70,3 +70,11 @@
 		border-radius: 9999px !important;
 	}
 }
+
+// This is needed to fix the images rendering as lines when lazy-loaded in Safari.
+// Targets Safari 9+ on iOS and macOS, works as of late 2025.
+@supports (font: -apple-system-body) {
+	img.stk-img {
+		will-change: transform;
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering issues for lazy‑loaded images in Safari on iOS/macOS to reduce flicker and improve visual stability.
  * Improved perceived performance for images that load lazily in affected Safari versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->