### PR TITLE
fix: exclude freemiums section to the global ul style for stackable

### DIFF
--- a/src/welcome/admin.scss
+++ b/src/welcome/admin.scss
@@ -439,6 +439,10 @@ body[class*="page_stk"] {
 		padding-left: 2em;
 		list-style-type: circle;
 	}
+	.fs-section ul {
+		list-style-type: none;
+	}
+
 	.s-box {
 		background-color: #fff;
 		border-radius: 0;


### PR DESCRIPTION
fixes #3681 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed bullet points from lists in a specific section, providing a cleaner and more refined visual appearance throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->