### PR TITLE
fix: avoid conflict in the enqueing script with conditional display

### DIFF
--- a/src/init.php
+++ b/src/init.php
@@ -237,7 +237,8 @@ if ( ! class_exists( 'Stackable_Init' ) ) {
 			}
 
 			// Enqueue the block script once.
-			if ( ! isset( self::$scripts_loaded[ $block['blockName'] ] ) ) {
+			// Do not enqueue if the block content is empty (e.g. due to conditional display)
+			if ( ! isset( self::$scripts_loaded[ $block['blockName'] ] ) && $block_content !== '' ) {
 				$stackable_block = substr( $block['blockName'], 10 );
 				do_action( 'stackable/' . $stackable_block . '/enqueue_scripts' );
 				self::$scripts_loaded[ $block['blockName'] ] = true;


### PR DESCRIPTION
fixes #3688
fixes #3693 

Issue: When the first carousel (or any other block with frontend script) in the post is removed using `Conditional Display`, its frontend script will not be enqueued.

The conditional display feature removes the block content of the blocks to avoid rendering the block. If there's no block content for that block, the `wp_enqueue_script` does not proceed (tested). However, the `$scripts_loaded` tracker, prior to this PR, attempts to enqueue the script, fails silently, but still records that the script is loaded. This will omit the succeeding attempts to enqueue the script, even though they are valid with proper block content.

This PR makes the `Conditional Display` run first to avoid race condition (in the premium PR), and check for empty block content before enqueueing the script since it might be removed with `Conditional Display` .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed script enqueuing behavior to prevent loading block scripts when block content is not displayed or conditionally hidden, improving overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->