### PR TITLE
fix: prevent shifting in safari

### DIFF
--- a/src/block/button/style.scss
+++ b/src/block/button/style.scss
@@ -28,3 +28,12 @@
 		box-sizing: border-box;
 	}
 }
+
+// Force Safari to render the SVG on its own layer to prevent shifting
+// during parent transition.
+// @see https://github.com/gambitph/Stackable/issues/3687
+@supports (font: -apple-system-body) {
+	.stk-button svg {
+		will-change: transform;
+	}
+}


### PR DESCRIPTION
fixes #3687 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized button rendering to reduce visual layout shifts during interactions, with enhanced stability for Safari browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->