### PR TITLE
fix: transform on <g> instead of <svg> as a safari fix

### DIFF
--- a/src/block-components/image/get-shape-css.js
+++ b/src/block-components/image/get-shape-css.js
@@ -30,9 +30,32 @@ export const getShapeCSS = ( shape, shapeFlipX, shapeFlipY, shapeStretch ) => {
 	const MaskImage = getShapeSVG( shape )
 	const MaskComp = <MaskImage
 		preserveAspectRatio={ ! [ '', 'square' ].includes( shape ) && shapeStretch ? 'none' : undefined }
-		transform={ ! shapeFlipX && ! shapeFlipY ? undefined : `scale(${ shapeFlipX ? -1 : 1 },${ shapeFlipY ? -1 : 1 })` }
 	/>
-	const maskString = btoa( svgRenderToString( MaskComp ) )
 
+	let svgString = svgRenderToString( MaskComp )
+
+	// Safari fix: instead of transform on <svg>, wrap contents in a <g> with transform
+	if ( shapeFlipX || shapeFlipY ) {
+		const scaleX = shapeFlipX ? -1 : 1
+		const scaleY = shapeFlipY ? -1 : 1
+
+		// Extract viewBox to compute translate offset
+		const viewBoxMatch = svgString.match( /viewBox="([^"]+)"/ )
+		const [ _minX, _minY, width, height ] = viewBoxMatch
+			? viewBoxMatch[ 1 ].split( ' ' ).map( Number )
+			: [ 0, 0, 100, 100 ]
+
+		const translateX = shapeFlipX ? width : 0
+		const translateY = shapeFlipY ? height : 0
+
+		// SVG transform are applied right to left
+		// Scale first (flip) and translate (reposition to view)
+		svgString = svgString.replace(
+			/(<svg[^>]*>)([\s\S]*)(<\/svg>)/,
+			`$1<g transform="translate(${ translateX },${ translateY }) scale(${ scaleX },${ scaleY })">$2</g>$3`
+		)
+	}
+
+	const maskString = btoa( svgString )
 	return `url('data:image/svg+xml;base64,${ maskString }')`
 }

--- a/src/block-components/image/get-shape-css.js
+++ b/src/block-components/image/get-shape-css.js
@@ -40,13 +40,12 @@ export const getShapeCSS = ( shape, shapeFlipX, shapeFlipY, shapeStretch ) => {
 		const scaleY = shapeFlipY ? -1 : 1
 
 		// Extract viewBox to compute translate offset
-		const viewBoxMatch = svgString.match( /viewBox="([^"]+)"/ )
-		const [ _minX, _minY, width, height ] = viewBoxMatch
-			? viewBoxMatch[ 1 ].split( ' ' ).map( Number )
-			: [ 0, 0, 100, 100 ]
+		const viewBoxMatch = svgString.match( /viewBox=["']([^"']+)["']/ )
+		const [ minX, minY, width, height ] = viewBoxMatch
+			? viewBoxMatch[ 1 ].trim().split( /[\s,]+/ ).map( Number ) : [ 0, 0, 100, 100 ]
 
-		const translateX = shapeFlipX ? width : 0
-		const translateY = shapeFlipY ? height : 0
+		const translateX = shapeFlipX ? width + ( 2 * minX ) : 0
+		const translateY = shapeFlipY ? height + ( 2 * minY ) : 0
 
 		// SVG transform are applied right to left
 		// Scale first (flip) and translate (reposition to view)


### PR DESCRIPTION
fixes #3650

Safari doesn't support transform on the root <svg> element when used as a CSS mask. The fix is to wrap the content in a <g> and apply the transform there instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed flipped image-shape rendering so horizontal and vertical flips now display consistently across contexts by embedding the flip into the image data. This resolves cases where flipped shapes appeared incorrect or misaligned, preserving intended appearance and layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->