### PR TITLE
fix: remove the delay in enabling of links after dragging

### DIFF
--- a/src/block/horizontal-scroller/frontend-horizontal-scroller.js
+++ b/src/block/horizontal-scroller/frontend-horizontal-scroller.js
@@ -68,12 +68,13 @@ class StackableHorizontalScroller {
 					behavior: 'smooth',
 				} )
 
+				children.forEach( child => {
+					// this enables the links after dragging
+					child.removeEventListener( 'click', onClickHandler, true )
+				} )
+
 				dragTimeout = setTimeout( () => {
 					el.classList.remove( 'stk--snapping-deactivated' )
-					children.forEach( child => {
-						// this enables the links after dragging
-						child.removeEventListener( 'click', onClickHandler, true )
-					 } )
 				}, 500 )
 			}
 


### PR DESCRIPTION
fixes #3694

Disabling of links when dragging and re-enabling them are introduced here: #2666. However, the re-enabling functionality is added to the snapping delay, making the links still unnecessarily disabled at that point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the horizontal scroller component where event listeners were being duplicated during drag interactions, improving performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->