### PR TITLE
fix: avoid rendering the design library modal again

### DIFF
--- a/src/plugins/guided-modal-tour/editor-block-tour.js
+++ b/src/plugins/guided-modal-tour/editor-block-tour.js
@@ -3,6 +3,13 @@ import { registerPlugin } from '@wordpress/plugins'
 import { useEffect, useState } from '@wordpress/element'
 import { GuidedModalTour } from '~stackable/components'
 
+// These tours render inside their own modal.
+// Rendering the tours here creates duplicate tour modals and
+// can close the owning modal unexpectedly.
+const MODAL_OWNED_TOURS = [
+	'design-library',
+]
+
 const EditorBlockTour = () => {
 	const [ tourId, setTourId ] = useState( 'blocks' )
 	useEffect( () => {
@@ -16,7 +23,7 @@ const EditorBlockTour = () => {
 	}, [] )
 
 	// Do not load if there is no tourId.
-	if ( ! tourId ) {
+	if ( ! tourId || MODAL_OWNED_TOURS.includes( tourId ) ) {
 		return null
 	}
 


### PR DESCRIPTION
fixes #3698

The issue is caused by the design library tour rendering more than once.

1. `src/plugins/guided-modal-tour/index.js` sees `tour=design-library` and clicks the Design Library toolbar button after 500ms. This part is correct and will render the guided tours triggered by the Design Library Modal.

2. `src/plugins/guided-modal-tour/editor-block-tour.js` also sees `tour=design-library` and renders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where certain guided tours could create duplicate modals and unexpectedly close related modals.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gambitph/Stackable/pull/3699)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->