### PR TITLE
fix: scope image box grid layout to direct content wrapper only

### DIFF
--- a/src/block/image-box/style.scss
+++ b/src/block/image-box/style.scss
@@ -2,7 +2,7 @@
 	.stk-block-column .stk-block-column__content {
 		justify-content: center;
 	}
-	.stk-inner-blocks {
+	> .stk-block-image-box__content {
 		display: grid;
 		> .stk-block {
 			grid-column: 1 / 2;


### PR DESCRIPTION
 fixes #3702

This fix also covers other affected stackable blocks with side-by-side layout (columns blocks, etc.). The grid layout enforced by image box should only be applied to the content wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined image box component layout to improve content alignment consistency across the interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gambitph/Stackable/pull/3706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->