### PR TITLE
fix: sanitize SVG without HTML reparsing

### DIFF
--- a/src/plugins/page-icons/page-icons.js
+++ b/src/plugins/page-icons/page-icons.js
@@ -1,6 +1,5 @@
 import './store'
 import { useSelect } from '@wordpress/data'
-import { safeHTML } from '@wordpress/dom'
 
 /**
  * Parse SVG string to extract attributes and innerHTML without DOM manipulation
@@ -43,6 +42,11 @@ const parseSVGString = svgString => {
 	rawInnerSVG = rawInnerSVG.replace( /\s[\w-]+:[\w-]+='[^']*'/g, '' )
 	rawInnerSVG = rawInnerSVG.replace( /\s[\w-]+:[\w-]+=[^\s"'=<>`]+/g, '' )
 
+	// Mimic safeHTML's event handler cleanup without parsing the SVG as HTML.
+	rawInnerSVG = rawInnerSVG.replace( /\son[\w-]+="[^"]*"/gi, '' )
+	rawInnerSVG = rawInnerSVG.replace( /\son[\w-]+='[^']*'/gi, '' )
+	rawInnerSVG = rawInnerSVG.replace( /\son[\w-]+=[^\s"'=<>`]+/gi, '' )
+
 	// Remove href/data-href/src attributes containing data: uris
 	rawInnerSVG = rawInnerSVG.replace(
 		/\s(?:href|data-href|src)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi,
@@ -58,8 +62,6 @@ const parseSVGString = svgString => {
 		}
 	)
 
-	const innerHTML = safeHTML( rawInnerSVG )
-
 	// Extract attributes from the SVG tag
 	const svgAttributes = {}
 	const attributesPart = svgTag.replace( /^<svg\s*/i, '' ).replace( />$/, '' )
@@ -71,7 +73,7 @@ const parseSVGString = svgString => {
 			const key = attrMatch[ 1 ]
 			const attrNameLower = key.toLowerCase()
 			// Skip width and height as symbols don't need them
-			if ( attrNameLower !== 'width' && attrNameLower !== 'height' ) {
+			if ( attrNameLower !== 'width' && attrNameLower !== 'height' && ! attrNameLower.startsWith( 'on' ) ) {
 				// Value can be in double quotes, single quotes, or unquoted
 				const value = attrMatch[ 2 ] || attrMatch[ 3 ] || attrMatch[ 4 ] || ''
 				svgAttributes[ key ] = value
@@ -79,7 +81,7 @@ const parseSVGString = svgString => {
 		}
 	}
 
-	return { attributes: svgAttributes, innerHTML }
+	return { attributes: svgAttributes, innerHTML: rawInnerSVG }
 }
 
 export const PageIcons = () => {

--- a/src/plugins/page-icons/page-icons.js
+++ b/src/plugins/page-icons/page-icons.js
@@ -43,9 +43,9 @@ const parseSVGString = svgString => {
 	rawInnerSVG = rawInnerSVG.replace( /\s[\w-]+:[\w-]+=[^\s"'=<>`]+/g, '' )
 
 	// Mimic safeHTML's event handler cleanup without parsing the SVG as HTML.
-	rawInnerSVG = rawInnerSVG.replace( /\son[\w-]+="[^"]*"/gi, '' )
-	rawInnerSVG = rawInnerSVG.replace( /\son[\w-]+='[^']*'/gi, '' )
-	rawInnerSVG = rawInnerSVG.replace( /\son[\w-]+=[^\s"'=<>`]+/gi, '' )
+	rawInnerSVG = rawInnerSVG.replace( /\son[\w-]+\s*=\s*"[^"]*"/gi, '' )
+	rawInnerSVG = rawInnerSVG.replace( /\son[\w-]+\s*=\s*'[^']*'/gi, '' )
+	rawInnerSVG = rawInnerSVG.replace( /\son[\w-]+\s*=\s*[^\s"'=<>`]+/gi, '' )
 
 	// Remove href/data-href/src attributes containing data: uris
 	rawInnerSVG = rawInnerSVG.replace(


### PR DESCRIPTION
fixes #3705 

`safeHTML()` is incompatible here because it sanitizes by parsing the input as HTML, not as SVG/XML.

It transforms: 
```
<path />
<path />
```

into:
```
<path>
	<path></path>
</path>
```

which makes it invalid. What we did is to get the the `safeHTML` code from `wordpress/dom` and only mimic the removal of `script` (already done) and `on`. For reference, this is the original implementation:

```
/**
 * Internal dependencies
 */
import remove from './remove';

/**
 * Strips scripts and on* attributes from HTML.
 *
 * @param {string} html HTML to sanitize.
 *
 * @return {string} The sanitized HTML.
 */
export default function safeHTML( html ) {
	const { body } = document.implementation.createHTMLDocument( '' );
	body.innerHTML = html;
	const elements = body.getElementsByTagName( '*' );
	let elementIndex = elements.length;

	while ( elementIndex-- ) {
		const element = elements[ elementIndex ];

		if ( element.tagName === 'SCRIPT' ) {
			remove( element );
		} else {
			let attributeIndex = element.attributes.length;

			while ( attributeIndex-- ) {
				const { name: key } = element.attributes[ attributeIndex ];

				if ( key.startsWith( 'on' ) ) {
					element.removeAttribute( key );
				}
			}
		}
	}

	return body.innerHTML;
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security of page icon SVG handling by strengthening sanitization of inline content and attributes to prevent potential vulnerabilities when processing icon data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gambitph/Stackable/pull/3707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->