### PR TITLE
fix/3708 test failure

### DIFF
--- a/.github/workflows/compressed-diff.yml
+++ b/.github/workflows/compressed-diff.yml
@@ -26,6 +26,7 @@ jobs:
     - uses: preactjs/compressed-size-action@v2
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        build-script: "build:no-translate"
         clean-script: "clean"
         pattern: "./build/stackable/**"
         exclude: "{**/*.map,**/node_modules/**}"

--- a/.github/workflows/compressed-diff.yml
+++ b/.github/workflows/compressed-diff.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2 # Checkout the Stackable Premium repo.
       with:
         repository: 'bfintal/Stackable-Premium'
-        ref: 'v3'
+        ref: 'develop'
         path: 'pro__premium_only'
         token: '${{ secrets.ACCESS_KEY }}'
     - name: Install Composer Dependencies

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,7 +15,7 @@ jobs:
           - php_version: '7.3'
             wp_version: 6.5.5
 
-          - php_version: '7.3'
+          - php_version: '7.4'
             wp_version: null
 
           - php_version: '8.2'

--- a/e2e/tests/block-editor.spec.ts
+++ b/e2e/tests/block-editor.spec.ts
@@ -103,11 +103,21 @@ test.describe( 'Block Editor', () => {
 	} ) => {
 		await editor.insertBlock( {
 			name: 'stackable/text',
-			attributes: {
-				text: 'test',
-				textColor1: '#ff0000',
-			},
 		} )
+
+		const settings = page.getByLabel( 'Settings', { exact: true } )
+
+		if ( await settings.getAttribute( 'aria-pressed' ) === 'false' ) {
+			await settings.click()
+		}
+
+		// Add content and color to Stackable Text Block
+		await editor.canvas.locator( '[data-type="stackable/text"] > .stk-block-text > p[role="textbox"]' ).fill( 'test' )
+		await page.locator( '.stk-color-palette-control .stk-control-content > .components-dropdown > .components-button' ).first().click()
+		await page.getByLabel( 'Hex color' ).fill( 'ff0000' )
+
+		// Click on the body to close the Color Picker popup
+		await editor.canvas.locator( 'body' ).click()
 
 		const clientId = await editor.canvas.getByLabel( 'Block: Text' ).getAttribute( 'data-block' )
 		const uniqueId = ( await editor.getBlockAttributes( clientId ) ).uniqueId


### PR DESCRIPTION
fixes #3708 

1. Updated the PHP version of the test from 7.3 to 7.4 for Wordpress 7.0.
2. Add the content and color attribute to the inserted text similar to how the previous tests did it (simulating like a user).

<img width="1073" height="194" alt="image" src="https://github.com/user-attachments/assets/45f0819b-f076-4d52-baca-dadb4c0ea267" />

3. Failed Compressed Size action is caused by the workflow that uses an outdated branch [v3](https://github.com/bfintal/Stackable-Premium/blob/v3/package.json) (which does not have the `build:no-translate` script). The fix is to use the updated `develop` branch instead. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Block Editor e2e test to more explicitly configure a text block in the editor and validate frontend rendering and PHP error behavior.

* **Chores**
  * CI workflows updated to run PHP 7.4.
  * Secondary repository checkout reference adjusted.
  * Compressed-size action configured to use a specific build script.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gambitph/Stackable/pull/3709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->