### PR TITLE
fix: update the editor breakpoints with wordpress 7.0 changes

### DIFF
--- a/src/compatibility/index.js
+++ b/src/compatibility/index.js
@@ -1,2 +1,3 @@
 import './kadence-theme'
 import './wp-6-2'
+import './wp-pre-7'

--- a/src/compatibility/wp-pre-7/index.js
+++ b/src/compatibility/wp-pre-7/index.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks'
+
+/**
+ * Internal dependencies
+ */
+import { semverCompare } from '~stackable/util'
+import { wpVersion } from 'stackable'
+
+addFilter( 'stackable.block-css.editor-preview-breakpoints', 'stackable/wp-pre-7', breakpoints => {
+	if ( wpVersion && semverCompare( wpVersion, '<', '7.0' ) ) {
+		return {
+			tablet: 781,
+			mobile: 361,
+		}
+	}
+
+	return breakpoints
+} )

--- a/src/components/block-css/index.js
+++ b/src/components/block-css/index.js
@@ -535,11 +535,16 @@ function createCssEdit( selector, rule, value, device = 'desktop', vendorPrefixe
 	}
 	css = `\n${ selector } {\n\t${ css }\n}`
 
-	// Match the Block Editor's fixed preview widths
-	// In WordPress 7.0, the preview widths have changed,
-	// see https://github.com/WordPress/gutenberg/pull/74339
-	const tabletBreakpoint = 782
-	const mobileBreakpoint = 480
+	// Match the Block Editor's fixed preview widths. getMediaQuery subtracts 1,
+	// so these default values target 781px tablet and 479px mobile in WordPress 7.0.
+	// https://github.com/WordPress/gutenberg/pull/74339
+	const { tablet: tabletBreakpoint, mobile: mobileBreakpoint } = applyFilters(
+		'stackable.block-css.editor-preview-breakpoints',
+		{
+			tablet: 782,
+			mobile: 480,
+		}
+	)
 
 	const mediaQuery = getMediaQuery( device, tabletBreakpoint, mobileBreakpoint )
 	if ( mediaQuery ) {

--- a/src/components/block-css/index.js
+++ b/src/components/block-css/index.js
@@ -535,9 +535,11 @@ function createCssEdit( selector, rule, value, device = 'desktop', vendorPrefixe
 	}
 	css = `\n${ selector } {\n\t${ css }\n}`
 
-	// The Block Editor has these fixed breakpoints.
-	const tabletBreakpoint = 781
-	const mobileBreakpoint = 361
+	// Match the Block Editor's fixed preview widths
+	// In WordPress 7.0, the preview widths have changed,
+	// see https://github.com/WordPress/gutenberg/pull/74339
+	const tabletBreakpoint = 782
+	const mobileBreakpoint = 480
 
 	const mediaQuery = getMediaQuery( device, tabletBreakpoint, mobileBreakpoint )
 	if ( mediaQuery ) {


### PR DESCRIPTION
fixes #3710

In Wordpress 7.0, editor breakpoints changed, see: https://github.com/WordPress/gutenberg/pull/74339/changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Block Editor responsive preview breakpoints to align with Gutenberg 7.0 standards, improving tablet and mobile preview accuracy.
  * Added compatibility handling so older WordPress versions retain their previous preview sizes, ensuring consistent editor previews across WP versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gambitph/Stackable/pull/3711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->