### PR TITLE
fix: ensure wp separator have full-width

### DIFF
--- a/src/styles/block.scss
+++ b/src/styles/block.scss
@@ -173,6 +173,12 @@
 	> *:last-child {
 		margin-bottom: 0;
 	}
+
+	// Separators inside .stk-inner-blocks become flex items. Explicitly setting width to 100%
+	// restores the expected full-width separator behavior.
+	.wp-block-separator {
+		width: 100%;
+	}
 }
 // Column with a block background has a padding that might not be obvious.
 .stk-block-background {

--- a/src/styles/editor-block.scss
+++ b/src/styles/editor-block.scss
@@ -326,3 +326,8 @@
 	justify-content: var(--stk-alignment-justify-content);
 }
 
+// Separators inside .stk-inner-blocks become flex items. Explicitly setting width to 100%
+// restores the expected full-width separator behavior.
+.stk-inner-blocks .wp-block-separator {
+	width: 100%;
+}


### PR DESCRIPTION
fixes #3712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed separator block width behavior to ensure full-width display in flex-based container layouts, maintaining consistent rendering across the editor and front-end interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->