### PR TITLE
fix: only allow transformation if stackable text is insertable

### DIFF
--- a/src/block/text/transforms.js
+++ b/src/block/text/transforms.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { createBlock, createBlocksFromInnerBlocksTemplate } from '@wordpress/blocks'
+import { select } from '@wordpress/data'
 
 /**
  * Internal dependencies
@@ -14,9 +15,10 @@ const transforms = {
 		// When pasting, ensure that the default text block setting is followed
 		{
 			type: 'raw',
-			isMatch: node =>
-				node.nodeName === 'P' &&
-				settings.stackable_enable_text_default_block,
+			isMatch: node => node.nodeName === 'P' &&
+				settings.stackable_enable_text_default_block &&
+				// Only allow transformation if stackable text can be inserted
+				select( 'core/block-editor' ).canInsertBlockType( 'stackable/text' ),
 			transform: node => {
 				return createBlock( 'stackable/text', {
 					text: node.textContent.trim(),


### PR DESCRIPTION
fixes #3718 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paragraph paste behavior so text only converts into the text block when it’s allowed in the current editor context.
  * Reduced cases where pasted plain paragraphs could transform unexpectedly, making content insertion more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->