### PR TITLE
fix/3714 hide api

### DIFF
--- a/src/components/admin-text-setting/index.js
+++ b/src/components/admin-text-setting/index.js
@@ -1,9 +1,9 @@
 import AdminBaseSetting from '../admin-base-setting'
-import { createRef, useState } from '@wordpress/element'
+import { useRef, useState } from '@wordpress/element'
 import { maskSensitiveValue } from '~stackable/util'
 
 const AdminTextSetting = props => {
-	const ref = createRef()
+	const ref = useRef()
 	const [ isEditing, setIsEditing ] = useState( false )
 	const value = props.maskValue && ! isEditing ? maskSensitiveValue( props.value ) : props.value
 

--- a/src/components/admin-text-setting/index.js
+++ b/src/components/admin-text-setting/index.js
@@ -1,13 +1,19 @@
 import AdminBaseSetting from '../admin-base-setting'
 import { createRef } from '@wordpress/element'
+import { maskSensitiveValue } from '~stackable/util'
 
 const AdminTextSetting = props => {
 	const ref = createRef()
+	const maskedValue = props.maskValue ? maskSensitiveValue( props.value ) : props.value
+
 	return (
 		<AdminBaseSetting
 			onClick={ ev => {
 				ev.preventDefault()
 				ref.current.focus()
+				if ( props.maskValue ) {
+					ref.current.select()
+				}
 			} }
 			{ ...props }
 		>
@@ -15,9 +21,18 @@ const AdminTextSetting = props => {
 				ref={ ref }
 				className="ugb-admin-text-setting"
 				type={ props.type }
-				value={ props.value }
+				value={ maskedValue }
 				placeholder={ props.placeholder }
+				autoComplete={ props.maskValue ? 'off' : undefined }
+				onFocus={ () => {
+					if ( props.maskValue ) {
+						ref.current.select()
+					}
+				} }
 				onChange={ event => {
+					if ( props.maskValue && event.target.value === maskedValue ) {
+						return
+					}
 					props.onChange( event.target.value )
 					event.preventDefault()
 					event.stopPropagation()
@@ -32,6 +47,7 @@ AdminTextSetting.defaultProps = {
 	label: '',
 	type: 'text',
 	value: '',
+	maskValue: false,
 	placeholder: '',
 	onChange: () => {},
 }

--- a/src/components/admin-text-setting/index.js
+++ b/src/components/admin-text-setting/index.js
@@ -1,10 +1,11 @@
 import AdminBaseSetting from '../admin-base-setting'
-import { createRef } from '@wordpress/element'
+import { createRef, useState } from '@wordpress/element'
 import { maskSensitiveValue } from '~stackable/util'
 
 const AdminTextSetting = props => {
 	const ref = createRef()
-	const maskedValue = props.maskValue ? maskSensitiveValue( props.value ) : props.value
+	const [ isEditing, setIsEditing ] = useState( false )
+	const value = props.maskValue && ! isEditing ? maskSensitiveValue( props.value ) : props.value
 
 	return (
 		<AdminBaseSetting
@@ -21,16 +22,20 @@ const AdminTextSetting = props => {
 				ref={ ref }
 				className="ugb-admin-text-setting"
 				type={ props.type }
-				value={ maskedValue }
+				value={ value }
 				placeholder={ props.placeholder }
 				autoComplete={ props.maskValue ? 'off' : undefined }
 				onFocus={ () => {
 					if ( props.maskValue ) {
-						ref.current.select()
+						setIsEditing( true )
+						setTimeout( () => ref.current?.select() )
 					}
 				} }
+				onBlur={ () => {
+					setIsEditing( false )
+				} }
 				onChange={ event => {
-					if ( props.maskValue && event.target.value === maskedValue ) {
+					if ( props.maskValue && ! isEditing ) {
 						return
 					}
 					props.onChange( event.target.value )

--- a/src/util/__test__/index.test.js
+++ b/src/util/__test__/index.test.js
@@ -2,8 +2,21 @@
  * Internal dependencies
  */
 import {
-	hexToRgba, prependCSSClass, compileCSS,
+	hexToRgba, prependCSSClass, compileCSS, maskSensitiveValue,
 } from '../'
+
+describe( 'maskSensitiveValue', () => {
+	it( 'fully masks values with 12 or fewer characters', () => {
+		expect( maskSensitiveValue( '' ) ).toBe( '' )
+		expect( maskSensitiveValue( '123456' ) ).toBe( '******' )
+		expect( maskSensitiveValue( '123456789012' ) ).toBe( '************' )
+	} )
+
+	it( 'keeps the first 6 and last 6 characters for longer values', () => {
+		expect( maskSensitiveValue( '1234567890123' ) ).toBe( '123456*890123' )
+		expect( maskSensitiveValue( 'abcdefghijklmnopqrstuvwxyz' ) ).toBe( 'abcdef**************uvwxyz' )
+	} )
+} )
 
 describe( 'hexToRgba', () => {
 	it( 'should work', () => {

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -39,15 +39,19 @@ export const getUniqueBlockClass = uniqueId => uniqueId ? `stk-${ uniqueId }` : 
  * Masks a sensitive string for display while keeping it recognizable.
  *
  * Shows the first 6 and last 6 characters, and replaces the middle characters
- * with asterisks. Values with 12 or fewer characters are returned as-is.
+ * with asterisks. Values with 12 or fewer characters are fully masked.
  *
  * @param {string} value The sensitive value to mask.
  *
  * @return {string} Masked value for display.
  */
 export const maskSensitiveValue = value => {
-	if ( ! value || value.length <= 12 ) {
+	if ( ! value ) {
 		return value
+	}
+
+	if ( value.length <= 12 ) {
+		return '*'.repeat( value.length )
 	}
 
 	return `${ value.slice( 0, 6 ) }${ '*'.repeat( value.length - 12 ) }${ value.slice( -6 ) }`

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -36,6 +36,24 @@ import { compare } from 'compare-versions'
 export const getUniqueBlockClass = uniqueId => uniqueId ? `stk-${ uniqueId }` : ''
 
 /**
+ * Masks a sensitive string for display while keeping it recognizable.
+ *
+ * Shows the first 6 and last 6 characters, and replaces the middle characters
+ * with asterisks. Values with 12 or fewer characters are returned as-is.
+ *
+ * @param {string} value The sensitive value to mask.
+ *
+ * @return {string} Masked value for display.
+ */
+export const maskSensitiveValue = value => {
+	if ( ! value || value.length <= 12 ) {
+		return value
+	}
+
+	return `${ value.slice( 0, 6 ) }${ '*'.repeat( value.length - 12 ) }${ value.slice( -6 ) }`
+}
+
+/**
  * Returns an array range of numbers.
  *
  * @param {number} start Starting number range.

--- a/src/welcome/admin.js
+++ b/src/welcome/admin.js
@@ -1357,6 +1357,7 @@ const Integrations = props => {
 								searchedSettings={ propsToPass.integrations.children }
 								value={ settings.stackable_google_maps_api_key }
 								type="text"
+								maskValue={ true }
 								onChange={ value => {
 									handleSettingsChange( { stackable_google_maps_api_key: value } ) // eslint-disable-line camelcase
 								} }


### PR DESCRIPTION
fixes #3714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional masking for sensitive text fields when not actively editing.
  * Google Maps API key input is now masked by default.
  * When a masked field is focused, the value is revealed and selected for editing.
* **Bug Fixes**
  * Prevents changes from being applied to masked fields while not in edit mode.
  * Disables browser autocomplete for masked fields.
* **Tests**
  * Added unit tests for the sensitive-value masking utility and its edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->