### PR TITLE
fix: Yoast SEO text highlighting for Stackable blocks

### DIFF
--- a/src/compatibility/index.js
+++ b/src/compatibility/index.js
@@ -1,3 +1,4 @@
 import './kadence-theme'
 import './wp-6-2'
 import './wp-pre-7'
+import './yoast-seo'

--- a/src/compatibility/yoast-seo/__test__/helpers.test.js
+++ b/src/compatibility/yoast-seo/__test__/helpers.test.js
@@ -1,0 +1,355 @@
+/**
+ * Internal dependencies
+ */
+import {
+	STACKABLE_ANNOTATABLE_BLOCKS,
+	FIELD_TO_STACKABLE_BLOCKS,
+	getFieldsToMark,
+	shouldAnnotateBlock,
+	getYoastmarkOffsets,
+	calculateAnnotationsForTextFormat,
+	createAnnotationsFromPositionBasedMarks,
+	getAnnotationsForStackableBlock,
+	getAnnotationsForStackableBlocks,
+} from '../helpers'
+
+/**
+ * Creates a mock Yoast Mark object for search-based highlighting.
+ *
+ * @param {string} original Sentence without yoastmark tags.
+ * @param {string} marked   Sentence with yoastmark tags.
+ * @param {Array}  fieldsToMark Optional fields to mark.
+ *
+ * @return {Object} Mock mark.
+ */
+const createSearchMark = ( original, marked, fieldsToMark = [] ) => ( {
+	getOriginal: () => original,
+	getMarked: () => marked,
+	getFieldsToMark: () => fieldsToMark,
+	hasBlockPosition: () => false,
+} )
+
+/**
+ * Creates a mock Yoast Mark object for position-based highlighting.
+ *
+ * @param {Object} options Mark options.
+ * @param {string} options.clientId Block client ID.
+ * @param {number} options.startOffsetBlock Block start offset.
+ * @param {number} options.endOffsetBlock Block end offset.
+ * @param {string} [options.original] Original text.
+ * @param {string} [options.marked] Marked text.
+ * @param {Array}  [options.fieldsToMark] Fields to mark.
+ *
+ * @return {Object} Mock mark.
+ */
+const createPositionMark = ( {
+	clientId,
+	startOffsetBlock,
+	endOffsetBlock,
+	original = '',
+	marked = '',
+	fieldsToMark = [],
+} ) => ( {
+	getOriginal: () => original,
+	getMarked: () => marked,
+	getFieldsToMark: () => fieldsToMark,
+	hasBlockPosition: () => true,
+	getBlockClientId: () => clientId,
+	getBlockPositionStart: () => startOffsetBlock,
+	getBlockPositionEnd: () => endOffsetBlock,
+} )
+
+const createBlock = ( name, clientId, attributes, innerBlocks = [] ) => ( {
+	name,
+	clientId,
+	attributes,
+	innerBlocks,
+} )
+
+describe( 'Yoast SEO compatibility helpers', () => {
+	describe( 'STACKABLE_ANNOTATABLE_BLOCKS', () => {
+		it( 'should map image blocks to figcaptionText', () => {
+			expect( STACKABLE_ANNOTATABLE_BLOCKS[ 'stackable/image' ] ).toEqual( {
+				attributeKey: 'figcaptionText',
+				richTextIdentifier: 'text',
+			} )
+		} )
+
+		it( 'should map text-based blocks to the text attribute', () => {
+			[ 'stackable/text', 'stackable/heading', 'stackable/subtitle', 'stackable/icon-list-item', 'stackable/button' ].forEach( blockName => {
+				expect( STACKABLE_ANNOTATABLE_BLOCKS[ blockName ] ).toEqual( {
+					attributeKey: 'text',
+					richTextIdentifier: 'text',
+				} )
+			} )
+		} )
+	} )
+
+	describe( 'FIELD_TO_STACKABLE_BLOCKS', () => {
+		it( 'should map field-specific assessments to the expected blocks', () => {
+			expect( FIELD_TO_STACKABLE_BLOCKS.heading ).toEqual( [ 'stackable/heading', 'stackable/subtitle' ] )
+			expect( FIELD_TO_STACKABLE_BLOCKS.paragraph ).toEqual( [ 'stackable/text', 'stackable/icon-list-item' ] )
+			expect( FIELD_TO_STACKABLE_BLOCKS.caption ).toEqual( [ 'stackable/image' ] )
+		} )
+
+		it( 'should allow button blocks through when fieldsToMark is empty', () => {
+			expect( shouldAnnotateBlock( { name: 'stackable/button' }, [] ) ).toBe( true )
+			expect( FIELD_TO_STACKABLE_BLOCKS.paragraph ).not.toContain( 'stackable/button' )
+		} )
+	} )
+
+	describe( 'getFieldsToMark', () => {
+		it( 'should collect unique fields from marks', () => {
+			const marks = [
+				createSearchMark( 'a', 'a', [ 'heading' ] ),
+				createSearchMark( 'b', 'b', [ 'paragraph', 'heading' ] ),
+			]
+
+			expect( getFieldsToMark( marks ) ).toEqual( [ 'heading', 'paragraph' ] )
+		} )
+	} )
+
+	describe( 'shouldAnnotateBlock', () => {
+		const textBlock = { name: 'stackable/text' }
+		const headingBlock = { name: 'stackable/heading' }
+		const imageBlock = { name: 'stackable/image' }
+		const buttonBlock = { name: 'stackable/button' }
+
+		it( 'should annotate all supported blocks when fieldsToMark is empty', () => {
+			expect( shouldAnnotateBlock( textBlock, [] ) ).toBe( true )
+			expect( shouldAnnotateBlock( headingBlock, [] ) ).toBe( true )
+			expect( shouldAnnotateBlock( imageBlock, [] ) ).toBe( true )
+			expect( shouldAnnotateBlock( buttonBlock, [] ) ).toBe( true )
+		} )
+
+		it( 'should only annotate heading blocks for heading fields', () => {
+			expect( shouldAnnotateBlock( headingBlock, [ 'heading' ] ) ).toBe( true )
+			expect( shouldAnnotateBlock( { name: 'stackable/subtitle' }, [ 'heading' ] ) ).toBe( true )
+			expect( shouldAnnotateBlock( textBlock, [ 'heading' ] ) ).toBe( false )
+		} )
+
+		it( 'should only annotate paragraph blocks for paragraph fields', () => {
+			expect( shouldAnnotateBlock( textBlock, [ 'paragraph' ] ) ).toBe( true )
+			expect( shouldAnnotateBlock( { name: 'stackable/icon-list-item' }, [ 'paragraph' ] ) ).toBe( true )
+			expect( shouldAnnotateBlock( headingBlock, [ 'paragraph' ] ) ).toBe( false )
+		} )
+
+		it( 'should only annotate image blocks for caption fields', () => {
+			expect( shouldAnnotateBlock( imageBlock, [ 'caption' ] ) ).toBe( true )
+			expect( shouldAnnotateBlock( textBlock, [ 'caption' ] ) ).toBe( false )
+		} )
+
+		it( 'should ignore unsupported blocks', () => {
+			expect( shouldAnnotateBlock( { name: 'stackable/columns' }, [] ) ).toBe( false )
+		} )
+	} )
+
+	describe( 'getYoastmarkOffsets', () => {
+		it( 'should extract offsets from single-quoted yoastmark tags', () => {
+			const marked = "Next, the field <yoastmark class='yoast-text-mark'>was selected</yoastmark> by the team."
+
+			expect( getYoastmarkOffsets( marked ) ).toEqual( [ {
+				startOffset: 16,
+				endOffset: 28,
+			} ] )
+		} )
+	} )
+
+	describe( 'calculateAnnotationsForTextFormat', () => {
+		it( 'should calculate offsets for passive voice style marks', () => {
+			const sentence = 'Next, the field that you want to fetch data from was selected.'
+			const mark = createSearchMark(
+				sentence,
+				"Next, the field that you want to fetch data from <yoastmark class='yoast-text-mark'>was selected</yoastmark>."
+			)
+
+			expect( calculateAnnotationsForTextFormat( sentence, mark ) ).toEqual( [ {
+				startOffset: 49,
+				endOffset: 61,
+			} ] )
+		} )
+
+		it( 'should return an empty array when the sentence is not found', () => {
+			const mark = createSearchMark(
+				'Missing sentence.',
+				"<yoastmark class='yoast-text-mark'>Missing sentence.</yoastmark>"
+			)
+
+			expect( calculateAnnotationsForTextFormat( 'Different content.', mark ) ).toEqual( [] )
+		} )
+	} )
+
+	describe( 'createAnnotationsFromPositionBasedMarks', () => {
+		it( 'should return annotations for matching client IDs', () => {
+			const mark = createPositionMark( {
+				clientId: 'block-1',
+				startOffsetBlock: 0,
+				endOffsetBlock: 11,
+			} )
+
+			expect(
+				createAnnotationsFromPositionBasedMarks(
+					mark,
+					'block-1',
+					'Giant panda',
+					'Giant panda'
+				)
+			).toEqual( [ {
+				startOffset: 0,
+				endOffset: 11,
+			} ] )
+		} )
+
+		it( 'should return an empty array for non-matching client IDs', () => {
+			const mark = createPositionMark( {
+				clientId: 'block-1',
+				startOffsetBlock: 0,
+				endOffsetBlock: 11,
+			} )
+
+			expect(
+				createAnnotationsFromPositionBasedMarks(
+					mark,
+					'block-2',
+					'Giant panda',
+					'Giant panda'
+				)
+			).toEqual( [] )
+		} )
+
+		it( 'should adjust offsets when HTML tags are present', () => {
+			const mark = createPositionMark( {
+				clientId: 'block-1',
+				startOffsetBlock: 16,
+				endOffsetBlock: 33,
+			} )
+
+			expect(
+				createAnnotationsFromPositionBasedMarks(
+					mark,
+					'block-1',
+					'This is a giant <strong>panda</strong>.',
+					'This is a giant panda.'
+				)
+			).toEqual( [ {
+				startOffset: 16,
+				endOffset: 25,
+			} ] )
+		} )
+	} )
+
+	describe( 'getAnnotationsForStackableBlock', () => {
+		it( 'should annotate stackable/text blocks', () => {
+			const sentence = 'The report was written by the team.'
+			const block = createBlock( 'stackable/text', 'text-1', {
+				text: sentence,
+			} )
+			const mark = createSearchMark(
+				sentence,
+				"The report <yoastmark class='yoast-text-mark'>was written by</yoastmark> the team."
+			)
+
+			expect( getAnnotationsForStackableBlock( block, [ mark ] ) ).toEqual( [ {
+				startOffset: 11,
+				endOffset: 25,
+				block: 'text-1',
+				richTextIdentifier: 'text',
+			} ] )
+		} )
+
+		it( 'should annotate stackable/image figcaption text', () => {
+			const caption = 'A photo was taken by the team.'
+			const block = createBlock( 'stackable/image', 'image-1', {
+				figcaptionText: caption,
+			} )
+			const mark = createSearchMark(
+				caption,
+				"A photo <yoastmark class='yoast-text-mark'>was taken by</yoastmark> the team."
+			)
+
+			expect( getAnnotationsForStackableBlock( block, [ mark ] ) ).toEqual( [ {
+				startOffset: 8,
+				endOffset: 20,
+				block: 'image-1',
+				richTextIdentifier: 'text',
+			} ] )
+		} )
+
+		it( 'should annotate stackable/button text', () => {
+			const buttonText = 'Click here to get started.'
+			const block = createBlock( 'stackable/button', 'button-1', {
+				text: buttonText,
+			} )
+			const mark = createSearchMark(
+				buttonText,
+				"Click <yoastmark class='yoast-text-mark'>here</yoastmark> to get started."
+			)
+
+			expect( getAnnotationsForStackableBlock( block, [ mark ] ) ).toEqual( [ {
+				startOffset: 6,
+				endOffset: 10,
+				block: 'button-1',
+				richTextIdentifier: 'text',
+			} ] )
+		} )
+	} )
+
+	describe( 'getAnnotationsForStackableBlocks', () => {
+		it( 'should recurse into inner blocks', () => {
+			const sentence = 'The report was written by the team.'
+			const innerBlock = createBlock( 'stackable/text', 'inner-text-1', {
+				text: sentence,
+			} )
+			const blocks = [
+				createBlock( 'stackable/columns', 'columns-1', {}, [ innerBlock ] ),
+			]
+			const mark = createSearchMark(
+				sentence,
+				"The report <yoastmark class='yoast-text-mark'>was written by</yoastmark> the team."
+			)
+
+			expect( getAnnotationsForStackableBlocks( blocks, [ mark ], [] ) ).toEqual( [ {
+				startOffset: 11,
+				endOffset: 25,
+				block: 'inner-text-1',
+				richTextIdentifier: 'text',
+			} ] )
+		} )
+
+		it( 'should respect fieldsToMark when filtering blocks', () => {
+			const textBlock = createBlock( 'stackable/text', 'text-1', {
+				text: 'Paragraph content.',
+			} )
+			const headingBlock = createBlock( 'stackable/heading', 'heading-1', {
+				text: 'Heading content.',
+			} )
+			const textMark = createSearchMark(
+				'Paragraph content.',
+				"<yoastmark class='yoast-text-mark'>Paragraph content.</yoastmark>",
+				[ 'paragraph' ]
+			)
+			const headingMark = createSearchMark(
+				'Heading content.',
+				"<yoastmark class='yoast-text-mark'>Heading content.</yoastmark>",
+				[ 'heading' ]
+			)
+
+			const paragraphAnnotations = getAnnotationsForStackableBlocks(
+				[ textBlock, headingBlock ],
+				[ textMark ],
+				[ 'paragraph' ]
+			)
+			const headingAnnotations = getAnnotationsForStackableBlocks(
+				[ textBlock, headingBlock ],
+				[ headingMark ],
+				[ 'heading' ]
+			)
+
+			expect( paragraphAnnotations ).toHaveLength( 1 )
+			expect( paragraphAnnotations[ 0 ].block ).toBe( 'text-1' )
+
+			expect( headingAnnotations ).toHaveLength( 1 )
+			expect( headingAnnotations[ 0 ].block ).toBe( 'heading-1' )
+		} )
+	} )
+} )

--- a/src/compatibility/yoast-seo/helpers.js
+++ b/src/compatibility/yoast-seo/helpers.js
@@ -1,0 +1,407 @@
+/**
+ * Yoast SEO compatibility helpers.
+ *
+ * Pure functions for mapping Yoast analysis marks to Stackable block annotations.
+ *
+ * @see https://github.com/gambitph/Stackable/issues/2422
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { create } from '@wordpress/rich-text'
+import {
+	flatMap, flatten, isUndefined, uniq,
+} from 'lodash'
+
+/**
+ * Stackable blocks that support Yoast SEO text highlighting.
+ * Maps block names to their annotatable attribute and RichText identifier.
+ */
+export const STACKABLE_ANNOTATABLE_BLOCKS = {
+	'stackable/text': {
+		attributeKey: 'text',
+		richTextIdentifier: 'text',
+	},
+	'stackable/heading': {
+		attributeKey: 'text',
+		richTextIdentifier: 'text',
+	},
+	'stackable/subtitle': {
+		attributeKey: 'text',
+		richTextIdentifier: 'text',
+	},
+	'stackable/icon-list-item': {
+		attributeKey: 'text',
+		richTextIdentifier: 'text',
+	},
+	'stackable/button': {
+		attributeKey: 'text',
+		richTextIdentifier: 'text',
+	},
+	'stackable/image': {
+		attributeKey: 'figcaptionText',
+		richTextIdentifier: 'text',
+	},
+}
+
+export const FIELD_TO_STACKABLE_BLOCKS = {
+	heading: [ 'stackable/heading', 'stackable/subtitle' ],
+	paragraph: [ 'stackable/text', 'stackable/icon-list-item' ],
+	caption: [ 'stackable/image' ],
+}
+
+const START_MARK = "<yoastmark class='yoast-text-mark'>"
+const END_MARK = '</yoastmark>'
+const START_MARK_DOUBLE_QUOTED = '<yoastmark class="yoast-text-mark">'
+
+const htmlTagsRegex = /(<([a-z]|\/)[^<>]+>)/ig
+const htmlEntitiesRegex = /&(?:[a-zA-Z]+|#[0-9]+|#x[0-9a-fA-F]+);/ig
+
+/**
+ * Retrieves the HTML for a block attribute.
+ *
+ * @param {Object} block The block.
+ * @param {string} attributeKey The attribute key.
+ *
+ * @return {string} The HTML.
+ */
+export const getBlockHtml = ( block, attributeKey ) => {
+	const richTextData = block.attributes[ attributeKey ]
+	return typeof richTextData === 'string' ? richTextData : ( richTextData || '' ).toString()
+}
+
+/**
+ * Gets the fields to mark from an array of Mark objects.
+ *
+ * @param {Array} marks Yoast Mark objects.
+ *
+ * @return {Array} Fields to mark.
+ */
+export const getFieldsToMark = marks => {
+	return uniq( flatten( marks.map( mark => {
+		if ( ! isUndefined( mark.getFieldsToMark ) ) {
+			return mark.getFieldsToMark()
+		}
+		return undefined
+	} ) ) )
+}
+
+/**
+ * Checks whether a block should receive annotations based on fieldsToMark.
+ *
+ * @param {Object} block The block.
+ * @param {Array}  fieldsToMark Fields to mark from Yoast marks.
+ *
+ * @return {boolean} Whether the block should be annotated.
+ */
+export const shouldAnnotateBlock = ( block, fieldsToMark ) => {
+	if ( ! STACKABLE_ANNOTATABLE_BLOCKS[ block.name ] ) {
+		return false
+	}
+
+	if ( fieldsToMark.length === 0 ) {
+		return true
+	}
+
+	return fieldsToMark.some( field => {
+		const stackableBlocks = FIELD_TO_STACKABLE_BLOCKS[ field ]
+		return stackableBlocks && stackableBlocks.includes( block.name )
+	} )
+}
+
+/**
+ * Finds all indices for a given string in a text.
+ *
+ * @param {string}  text Text to search through.
+ * @param {string}  stringToFind Text to search for.
+ * @param {boolean} caseSensitive Whether the search is case-sensitive.
+ *
+ * @return {number[]} All indices of the found occurrences.
+ */
+export const getIndicesOf = ( text, stringToFind, caseSensitive = true ) => {
+	const indices = []
+	if ( text.length === 0 ) {
+		return indices
+	}
+
+	let searchStartIndex = 0
+	let index
+
+	if ( ! caseSensitive ) {
+		stringToFind = stringToFind.toLowerCase()
+		text = text.toLowerCase()
+	}
+
+	while ( ( index = text.indexOf( stringToFind, searchStartIndex ) ) > -1 ) {
+		indices.push( index )
+		searchStartIndex = index + stringToFind.length
+	}
+
+	return indices
+}
+
+/**
+ * Returns the offsets of yoastmark occurrences in a marked sentence.
+ *
+ * @param {string} markedSentence The marked sentence.
+ *
+ * @return {Array} Start and end offsets.
+ */
+export const getYoastmarkOffsets = markedSentence => {
+	let startMarkIndex = markedSentence.indexOf( START_MARK )
+	const doesNotContainDoubleQuotedMark = startMarkIndex >= 0
+
+	if ( ! doesNotContainDoubleQuotedMark ) {
+		startMarkIndex = markedSentence.indexOf( START_MARK_DOUBLE_QUOTED )
+	}
+
+	const offsets = []
+
+	while ( startMarkIndex >= 0 ) {
+		markedSentence = doesNotContainDoubleQuotedMark
+			? markedSentence.replace( START_MARK, '' )
+			: markedSentence.replace( START_MARK_DOUBLE_QUOTED, '' )
+
+		const endMarkIndex = markedSentence.indexOf( END_MARK )
+		if ( endMarkIndex < startMarkIndex ) {
+			return []
+		}
+		markedSentence = markedSentence.replace( END_MARK, '' )
+
+		offsets.push( {
+			startOffset: startMarkIndex,
+			endOffset: endMarkIndex,
+		} )
+
+		startMarkIndex = doesNotContainDoubleQuotedMark
+			? markedSentence.indexOf( START_MARK )
+			: markedSentence.indexOf( START_MARK_DOUBLE_QUOTED )
+	}
+
+	return offsets
+}
+
+/**
+ * Calculates annotations using search-based highlighting.
+ *
+ * @param {string} text The content of the block.
+ * @param {Object} mark The Yoast mark object.
+ *
+ * @return {Array} Annotation ranges.
+ */
+export const calculateAnnotationsForTextFormat = ( text, mark ) => {
+	const originalSentence = mark.getOriginal().replace( /(<([^>]+)>)/ig, '' )
+	const markedSentence = mark.getMarked().replace( /(<(?!\/?yoastmark)[^>]+>)/ig, '' )
+	const sentenceIndices = getIndicesOf( text, originalSentence )
+
+	if ( sentenceIndices.length === 0 ) {
+		return []
+	}
+
+	const yoastmarkOffsets = getYoastmarkOffsets( markedSentence )
+	const blockOffsets = []
+
+	yoastmarkOffsets.forEach( yoastmarkOffset => {
+		sentenceIndices.forEach( sentenceIndex => {
+			const startOffset = sentenceIndex + yoastmarkOffset.startOffset
+			let endOffset = sentenceIndex + yoastmarkOffset.endOffset
+
+			if ( yoastmarkOffset.startOffset === 0 && yoastmarkOffset.endOffset === mark.getOriginal().length ) {
+				endOffset = sentenceIndex + originalSentence.length
+			}
+
+			blockOffsets.push( { startOffset, endOffset } )
+		} )
+	} )
+
+	return blockOffsets
+}
+
+/**
+ * Retrieves the length for HTML tags, adjusting for br tags.
+ *
+ * @param {Array} htmlTags Matched HTML tags.
+ *
+ * @return {number} Total tag length.
+ */
+const getTagsLength = htmlTags => {
+	let tagsLength = 0
+	for ( let i = htmlTags.length - 1; i >= 0; i-- ) {
+		const [ tag ] = htmlTags[ i ]
+		let tagLength = tag.length
+		if ( /^<\/?br/.test( tag ) ) {
+			tagLength -= 1
+		}
+		tagsLength += tagLength
+	}
+	return tagsLength
+}
+
+/**
+ * Adjusts mark offsets when the block HTML contains HTML tags.
+ *
+ * @param {string} slicedBlockHtmlToStartOffset HTML slice to start offset.
+ * @param {string} slicedBlockHtmlToEndOffset   HTML slice to end offset.
+ * @param {number} blockStartOffset             Block start offset.
+ * @param {number} blockEndOffset               Block end offset.
+ *
+ * @return {Object} Adjusted offsets.
+ */
+const adjustOffsetsForHtmlTags = ( slicedBlockHtmlToStartOffset, slicedBlockHtmlToEndOffset, blockStartOffset, blockEndOffset ) => {
+	const foundHtmlTagsToStartOffset = [ ...slicedBlockHtmlToStartOffset.matchAll( htmlTagsRegex ) ]
+	blockStartOffset -= getTagsLength( foundHtmlTagsToStartOffset )
+
+	const foundHtmlTagsToEndOffset = [ ...slicedBlockHtmlToEndOffset.matchAll( htmlTagsRegex ) ]
+	blockEndOffset -= getTagsLength( foundHtmlTagsToEndOffset )
+
+	return { blockStartOffset, blockEndOffset }
+}
+
+/**
+ * Adjusts mark offsets when the block HTML contains HTML entities.
+ *
+ * @param {string} slicedBlockHtmlToStartOffset HTML slice to start offset.
+ * @param {string} slicedBlockHtmlToEndOffset   HTML slice to end offset.
+ * @param {number} blockStartOffset             Block start offset.
+ * @param {number} blockEndOffset               Block end offset.
+ *
+ * @return {Object} Adjusted offsets.
+ */
+const adjustOffsetsForHtmlEntities = ( slicedBlockHtmlToStartOffset, slicedBlockHtmlToEndOffset, blockStartOffset, blockEndOffset ) => {
+	let matchedHtmlEntities = [ ...slicedBlockHtmlToStartOffset.matchAll( htmlEntitiesRegex ) ]
+	for ( let i = matchedHtmlEntities.length - 1; i >= 0; i-- ) {
+		const [ , matchedEntityWithoutAmp ] = matchedHtmlEntities[ i ]
+		blockStartOffset -= matchedEntityWithoutAmp.length
+	}
+
+	matchedHtmlEntities = [ ...slicedBlockHtmlToEndOffset.matchAll( htmlEntitiesRegex ) ]
+	for ( let i = matchedHtmlEntities.length - 1; i >= 0; i-- ) {
+		const [ , matchedEntityWithoutAmp ] = matchedHtmlEntities[ i ]
+		blockEndOffset -= matchedEntityWithoutAmp.length
+	}
+
+	return { blockStartOffset, blockEndOffset }
+}
+
+/**
+ * Adjusts mark offsets for HTML tags and entities.
+ *
+ * @param {number} blockStartOffset Block start offset.
+ * @param {number} blockEndOffset   Block end offset.
+ * @param {string} blockHtml        Block HTML.
+ *
+ * @return {Object} Adjusted offsets.
+ */
+const adjustMarkOffsets = ( blockStartOffset, blockEndOffset, blockHtml ) => {
+	const slicedBlockHtmlToStartOffset = blockHtml.slice( 0, blockStartOffset )
+	const slicedBlockHtmlToEndOffset = blockHtml.slice( 0, blockEndOffset )
+
+	const adjustedOffsetsInCaseOfHtmlTags = adjustOffsetsForHtmlTags(
+		slicedBlockHtmlToStartOffset,
+		slicedBlockHtmlToEndOffset,
+		blockStartOffset,
+		blockEndOffset
+	)
+	blockStartOffset = adjustedOffsetsInCaseOfHtmlTags.blockStartOffset
+	blockEndOffset = adjustedOffsetsInCaseOfHtmlTags.blockEndOffset
+
+	const adjustedOffsetsInCaseOfHtmlEntities = adjustOffsetsForHtmlEntities(
+		slicedBlockHtmlToStartOffset,
+		slicedBlockHtmlToEndOffset,
+		blockStartOffset,
+		blockEndOffset
+	)
+
+	return adjustedOffsetsInCaseOfHtmlEntities
+}
+
+/**
+ * Creates annotations from position-based marks.
+ *
+ * @param {Object} mark           Yoast mark object.
+ * @param {string} blockClientId  Block client ID.
+ * @param {string} blockHtml      Block HTML.
+ * @param {string} richText       Block plain text.
+ *
+ * @return {Array} Annotation ranges.
+ */
+export const createAnnotationsFromPositionBasedMarks = ( mark, blockClientId, blockHtml, richText ) => {
+	if ( blockClientId !== mark.getBlockClientId() ) {
+		return []
+	}
+
+	const blockStartOffset = mark.getBlockPositionStart()
+	const blockEndOffset = mark.getBlockPositionEnd()
+
+	const slicedHtml = blockHtml.slice( blockStartOffset, blockEndOffset )
+	const slicedRichText = richText.slice( blockStartOffset, blockEndOffset )
+
+	if ( slicedHtml === slicedRichText ) {
+		return [ { startOffset: blockStartOffset, endOffset: blockEndOffset } ]
+	}
+
+	const adjustedMarkOffsets = adjustMarkOffsets( blockStartOffset, blockEndOffset, blockHtml )
+	return [ {
+		startOffset: adjustedMarkOffsets.blockStartOffset,
+		endOffset: adjustedMarkOffsets.blockEndOffset,
+	} ]
+}
+
+/**
+ * Creates annotations for a Stackable text block.
+ *
+ * @param {Object} block The block.
+ * @param {Array}  marks Yoast mark objects.
+ *
+ * @return {Array} Annotations to apply.
+ */
+export const getAnnotationsForStackableBlock = ( block, marks ) => {
+	const { attributeKey, richTextIdentifier } = STACKABLE_ANNOTATABLE_BLOCKS[ block.name ]
+	const blockHtml = getBlockHtml( block, attributeKey )
+
+	const record = create( { html: blockHtml } )
+	const richText = record.text
+
+	return flatMap( marks, mark => {
+		let annotations
+		if ( mark.hasBlockPosition && mark.hasBlockPosition() ) {
+			annotations = createAnnotationsFromPositionBasedMarks( mark, block.clientId, blockHtml, richText )
+		} else {
+			annotations = calculateAnnotationsForTextFormat( richText, mark )
+		}
+
+		if ( ! annotations ) {
+			return []
+		}
+
+		return annotations.map( annotation => ( {
+			...annotation,
+			block: block.clientId,
+			richTextIdentifier,
+		} ) )
+	} )
+}
+
+/**
+ * Recursively gets annotations for Stackable blocks.
+ *
+ * @param {Array} blocks Editor blocks.
+ * @param {Array} marks  Yoast mark objects.
+ * @param {Array} fieldsToMark Fields to mark.
+ *
+ * @return {Array} Annotations to apply.
+ */
+export const getAnnotationsForStackableBlocks = ( blocks, marks, fieldsToMark ) => {
+	return flatMap( blocks, block => {
+		const innerBlockAnnotations = block.innerBlocks?.length
+			? getAnnotationsForStackableBlocks( block.innerBlocks, marks, fieldsToMark )
+			: []
+
+		if ( ! shouldAnnotateBlock( block, fieldsToMark ) ) {
+			return innerBlockAnnotations
+		}
+
+		return getAnnotationsForStackableBlock( block, marks ).concat( innerBlockAnnotations )
+	} )
+}

--- a/src/compatibility/yoast-seo/index.js
+++ b/src/compatibility/yoast-seo/index.js
@@ -1,0 +1,235 @@
+/**
+ * Yoast SEO compatibility.
+ *
+ * Applies Yoast SEO analysis highlights to Stackable text-based blocks.
+ * Yoast only annotates core blocks by default; this hooks into yoast.analysis.applyMarks.
+ *
+ * @see https://github.com/gambitph/Stackable/issues/2422
+ */
+
+/**
+ * Internal dependencies
+ */
+import {
+	getAnnotationsForStackableBlock,
+	getAnnotationsForStackableBlocks,
+	getFieldsToMark,
+	shouldAnnotateBlock,
+	STACKABLE_ANNOTATABLE_BLOCKS,
+} from './helpers'
+
+/**
+ * WordPress dependencies
+ */
+import {
+	dispatch, select, subscribe,
+} from '@wordpress/data'
+import { addAction } from '@wordpress/hooks'
+import { isFunction } from 'lodash'
+
+const ANNOTATION_SOURCE = 'yoast'
+
+let annotationQueue = []
+let previousSelectedBlockId = null
+let previousActiveMarkerId = null
+
+/**
+ * Returns whether annotations are available in the block editor.
+ *
+ * @return {boolean} Whether annotations can be applied.
+ */
+const isAnnotationAvailable = () => {
+	return select( 'core/block-editor' ) &&
+		isFunction( select( 'core/block-editor' ).getBlocks ) &&
+		select( 'core/annotations' ) &&
+		isFunction( dispatch( 'core/annotations' ).__experimentalAddAnnotation )
+}
+
+/**
+ * Returns whether Yoast SEO is active in the editor.
+ *
+ * @return {boolean} Whether Yoast SEO is available.
+ */
+const isYoastSeoAvailable = () => {
+	return select( 'yoast-seo/editor' ) &&
+		isFunction( select( 'yoast-seo/editor' ).getActiveMarker )
+}
+
+/**
+ * Gets all blocks to scan for annotations.
+ *
+ * @return {Array} Blocks in the editor.
+ */
+const getEditorBlocks = () => {
+	const blockEditorDataModule = select( 'core/block-editor' )
+	const editorDataModule = select( 'core/editor' )
+
+	if ( ! blockEditorDataModule || ! editorDataModule ) {
+		return []
+	}
+
+	const isTemplateLocked = editorDataModule.getRenderingMode?.() === 'template-locked'
+	const postContentBlock = blockEditorDataModule.getBlocksByName( 'core/post-content' )
+
+	return ( isTemplateLocked && postContentBlock?.length )
+		? blockEditorDataModule.getBlocks( postContentBlock[ 0 ] )
+		: blockEditorDataModule.getBlocks()
+}
+
+/**
+ * Applies the next annotation in the queue.
+ *
+ * @return {void}
+ */
+const applyAnnotationQueueItem = () => {
+	const nextAnnotation = annotationQueue.shift()
+	if ( ! nextAnnotation ) {
+		return
+	}
+
+	dispatch( 'core/annotations' ).__experimentalAddAnnotation( nextAnnotation )
+	scheduleAnnotationQueueApplication()
+}
+
+/**
+ * Schedules the application of the next annotation in the queue.
+ *
+ * @return {void}
+ */
+const scheduleAnnotationQueueApplication = () => {
+	if ( isFunction( window.requestIdleCallback ) ) {
+		window.requestIdleCallback( applyAnnotationQueueItem, { timeout: 1000 } )
+	} else {
+		setTimeout( applyAnnotationQueueItem, 150 )
+	}
+}
+
+/**
+ * Formats annotations and adds them to the queue.
+ *
+ * @param {Array} annotations Annotations to queue.
+ *
+ * @return {void}
+ */
+const fillAnnotationQueue = annotations => {
+	annotationQueue = annotations.map( annotation => ( {
+		blockClientId: annotation.block,
+		source: ANNOTATION_SOURCE,
+		richTextIdentifier: annotation.richTextIdentifier,
+		range: {
+			start: annotation.startOffset,
+			end: annotation.endOffset,
+		},
+	} ) )
+
+	scheduleAnnotationQueueApplication()
+}
+
+/**
+ * Removes annotations from a single block.
+ *
+ * @param {string} blockClientId Block client ID.
+ *
+ * @return {void}
+ */
+const removeAnnotationsFromBlock = blockClientId => {
+	const annotationsInBlock = select( 'core/annotations' )
+		.__experimentalGetAnnotations()
+		.filter( annotation => annotation.blockClientId === blockClientId && annotation.source === ANNOTATION_SOURCE )
+
+	annotationsInBlock.forEach( annotation => {
+		dispatch( 'core/annotations' ).__experimentalRemoveAnnotation( annotation.id )
+	} )
+}
+
+/**
+ * Applies Yoast marks as annotations on Stackable text blocks.
+ *
+ * @param {Array} marks Yoast mark objects.
+ *
+ * @return {void}
+ */
+const applyStackableAnnotations = marks => {
+	if ( ! isAnnotationAvailable() || ! marks?.length ) {
+		return
+	}
+
+	const fieldsToMark = getFieldsToMark( marks )
+	const blocks = getEditorBlocks()
+	const annotations = getAnnotationsForStackableBlocks( blocks, marks, fieldsToMark )
+
+	if ( annotations.length > 0 ) {
+		fillAnnotationQueue( annotations )
+	}
+}
+
+/**
+ * Reapplies annotations for the currently selected Stackable block.
+ *
+ * @return {void}
+ */
+const reapplyAnnotationsForSelectedStackableBlock = () => {
+	if ( ! isAnnotationAvailable() || ! isYoastSeoAvailable() ) {
+		return
+	}
+
+	const block = select( 'core/block-editor' ).getSelectedBlock()
+	const activeMarkerId = select( 'yoast-seo/editor' ).getActiveMarker()
+
+	if ( ! block || ! activeMarkerId || ! STACKABLE_ANNOTATABLE_BLOCKS[ block.name ] ) {
+		return
+	}
+
+	if ( block.clientId === previousSelectedBlockId && activeMarkerId === previousActiveMarkerId ) {
+		return
+	}
+
+	previousSelectedBlockId = block.clientId
+	previousActiveMarkerId = activeMarkerId
+
+	const activeMarker = select( 'yoast-seo/editor' ).getResultById( activeMarkerId )
+	if ( typeof activeMarker === 'undefined' ) {
+		return
+	}
+
+	removeAnnotationsFromBlock( block.clientId )
+
+	const fieldsToMark = getFieldsToMark( activeMarker.marks )
+	if ( ! shouldAnnotateBlock( block, fieldsToMark ) ) {
+		return
+	}
+
+	const annotations = getAnnotationsForStackableBlock( block, activeMarker.marks )
+	if ( annotations.length > 0 ) {
+		fillAnnotationQueue( annotations )
+	}
+}
+
+/**
+ * Initializes Yoast SEO highlighting compatibility for Stackable text blocks.
+ *
+ * @return {void}
+ */
+const initYoastSeoCompatibility = () => {
+	if ( ! isAnnotationAvailable() ) {
+		return
+	}
+
+	addAction( 'yoast.analysis.applyMarks', 'stackable/yoast-seo', applyStackableAnnotations )
+
+	subscribe( reapplyAnnotationsForSelectedStackableBlock )
+}
+
+// Yoast SEO loads after Stackable, so wait until the editor is ready.
+if ( typeof window !== 'undefined' ) {
+	if ( isYoastSeoAvailable() ) {
+		initYoastSeoCompatibility()
+	} else {
+		const unsubscribe = subscribe( () => {
+			if ( isYoastSeoAvailable() ) {
+				unsubscribe()
+				initYoastSeoCompatibility()
+			}
+		} )
+	}
+}


### PR DESCRIPTION
## Summary

- Adds Yoast SEO compatibility so analysis highlights (e.g. passive voice) work in Stackable text-based blocks
- Hooks into `yoast.analysis.applyMarks` and applies Gutenberg annotations to supported blocks
- Covers Text, Heading, Subtitle, Icon List Item, Image caption, and Button blocks
- Includes unit tests for annotation offset logic and `fieldsToMark` filtering

Fixes #2422

## Test plan

- [ ] Install Yoast SEO on a test site
- [ ] Add Stackable Text block with passive voice sentence from #2422 repro
- [ ] Open Yoast Readability → Passive voice → click highlight (eye icon)
- [ ] Confirm highlighted text appears in the Stackable block
- [ ] Repeat for Heading, Subtitle, Icon List Item, Button, and Image caption blocks
- [ ] Run unit tests: `npx jest src/compatibility/yoast-seo/__test__/helpers.test.js`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility with Yoast SEO analysis in the Stackable editor.
  * Yoast SEO recommendations can now highlight relevant text within supported Stackable blocks.
  * Highlights update automatically when selecting blocks or changing the active Yoast marker.
  * Supports annotations in text, button, image caption, and nested block content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->