### PR TITLE
ci: speed up Playwright workflow with shared build job

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,11 +19,11 @@ jobs:
         npm ci --legacy-peer-deps
         npm run build:no-translate
     - name: Archive plugin build
-      run: tar --exclude=./node_modules --exclude=./.git -czf stackable-playwright-build.tar.gz .
+      run: tar --exclude=./node_modules --exclude=./.git -czf /tmp/stackable-playwright-build.tar.gz .
     - uses: actions/upload-artifact@v4
       with:
         name: stackable-playwright-build
-        path: stackable-playwright-build.tar.gz
+        path: /tmp/stackable-playwright-build.tar.gz
         retention-days: 1
 
   test:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,7 +5,29 @@ on:
   pull_request:
     branches: [ master, develop ]
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+        cache: npm
+        cache-dependency-path: package-lock.json
+    - name: Build Stackable Free Plugin
+      run: |
+        npm ci --legacy-peer-deps
+        npm run build:no-translate
+    - name: Archive plugin build
+      run: tar --exclude=./node_modules --exclude=./.git -czf stackable-playwright-build.tar.gz .
+    - uses: actions/upload-artifact@v4
+      with:
+        name: stackable-playwright-build
+        path: stackable-playwright-build.tar.gz
+        retention-days: 1
+
   test:
+    needs: build
     timeout-minutes: 60
     runs-on: ubuntu-latest
     strategy:
@@ -28,6 +50,16 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*
+        cache: npm
+        cache-dependency-path: package-lock.json
+    - name: Restore plugin build
+      uses: actions/download-artifact@v4
+      with:
+        name: stackable-playwright-build
+    - name: Extract plugin build
+      run: tar -xzf stackable-playwright-build.tar.gz
+    - name: Install dependencies
+      run: npm ci --legacy-peer-deps
     - name: Set the version suffix for the output
       run: echo VERSION_SUFFIX=${GITHUB_REF_NAME//\//-} >> $GITHUB_ENV
     - name: Set WP Version and create .wp-env.json
@@ -52,10 +84,6 @@ jobs:
           }' > .wp-env.json
 
         cat .wp-env.json
-    - name: Build Stackable Free Plugin
-      run: |
-        npm ci --legacy-peer-deps
-        npm run build:no-translate
     - name: Cache Playwright Browsers
       uses: actions/cache@v4
       with:
@@ -72,22 +100,19 @@ jobs:
           sleep $((attempt * 30))
         done
         exit 1
-    - name: Install wp-env
-      run: |
-        npm install -g @wordpress/env
     - name: Start wp-env
-      run: wp-env start
+      run: npx @wordpress/env start
     - name: Print current WP version
-      run: wp-env run tests-cli wp core version
+      run: npx @wordpress/env run tests-cli wp core version
     - name: Create post with existing blocks
       run: |
-        POST_ID=$(wp-env run tests-cli wp post create wp-content/plugins/Stackable/e2e/config/post-content.txt --post_title="Existing Blocks" --post_status=publish --porcelain)
+        POST_ID=$(npx @wordpress/env run tests-cli wp post create wp-content/plugins/Stackable/e2e/config/post-content.txt --post_title="Existing Blocks" --post_status=publish --porcelain)
         echo "WP_TEST_POSTID=$POST_ID" >> $GITHUB_ENV
       continue-on-error: true
     - name: Disable guided tours
       run: |
         TOUR_STATES='["design-system", "editor", "design-library", "blocks"]'
-        wp-env run tests-cli wp option update stackable_guided_tour_states "$TOUR_STATES" --format=json
+        npx @wordpress/env run tests-cli wp option update stackable_guided_tour_states "$TOUR_STATES" --format=json
     - name: Run playwright tests
       id: run-playwright-tests
       env:


### PR DESCRIPTION
## Summary
- Add a shared `build` job that compiles the plugin once and uploads a tarball artifact
- Matrix `test` jobs download the artifact instead of rebuilding on every WP/PHP combination
- Enable npm caching via `setup-node` for faster `npm ci` on build and test jobs
- Replace global `wp-env` install with `npx @wordpress/env`

## Test plan
- [ ] Playwright workflow completes on all 4 matrix jobs (PHP 8.5/7.4 × WP 7.0.1/6.9.4/6.8.5)
- [ ] Build job artifact is reused successfully by test jobs
- [ ] Total workflow time is reduced vs previous matrix-only setup


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by separating plugin build from test execution.
  * Reuses a pre-built plugin artifact during Playwright runs to reduce redundant work.
  * Updated the WordPress test environment flow to start via the standard env runner, initialize core checks, create the required “Existing Blocks” content (allowing non-fatal failures), and apply guided tour configuration for the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->