### PR TITLE
fix: preserve custom CSS in free

### DIFF
--- a/src/block-components/custom-css/index.js
+++ b/src/block-components/custom-css/index.js
@@ -1,10 +1,29 @@
 import { addAttributes } from './attributes'
 import { Edit } from './edit'
+import { useBlockAttributesContext } from '~stackable/hooks'
 
 import { applyFilters } from '@wordpress/hooks'
 
+// Keep existing Premium Custom CSS working when Premium is deactivated.
+const CustomCSSStyle = props => {
+	const { css, isSaveContent } = props
+
+	return !! css && <style className={ isSaveContent ? 'stk-custom-css' : undefined }>{ css }</style>
+}
+
+CustomCSSStyle.defaultProps = {
+	css: '',
+	isSaveContent: false,
+}
+
 export const CustomCSS = props => {
-	return applyFilters( 'stackable.block-component.custom-css', null, props )
+	const customCSSMinified = useBlockAttributesContext( attributes => attributes.customCSSMinified )
+
+	return applyFilters(
+		'stackable.block-component.custom-css',
+		<CustomCSSStyle css={ customCSSMinified } />,
+		props
+	)
 }
 
 CustomCSS.defaultProps = {
@@ -12,7 +31,11 @@ CustomCSS.defaultProps = {
 }
 
 CustomCSS.Content = props => {
-	return applyFilters( 'stackable.block-component.custom-css.content', null, props )
+	return applyFilters(
+		'stackable.block-component.custom-css.content',
+		<CustomCSSStyle css={ props.attributes.customCSSMinified } isSaveContent />,
+		props
+	)
 }
 
 CustomCSS.Content.defaultProps = {


### PR DESCRIPTION
fixes #3733

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom CSS is now consistently rendered when saved in block settings.
  * Improved handling of saved content and default styling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Test plan

### Free / Premium deactivated (main fix)
- [ ] With Premium active, add Custom CSS to a Stackable block, save the post, then deactivate Premium (or switch to free)
- [ ] Reopen the editor → Custom CSS styles still apply in the editor preview
- [ ] View the frontend → Custom CSS still applies
- [ ] Saved markup still includes `<style class="stk-custom-css">…</style>` and is not stripped on save
- [ ] Opening/saving the post again does not wipe `customCSSMinified` or dirty the document unexpectedly

### Premium still active (regression)
- [ ] Custom CSS inspector control still appears and can edit CSS
- [ ] Editor live preview updates when Custom CSS changes
- [ ] Frontend output matches after save
- [ ] No duplicate `<style>` tags for Custom CSS in editor or saved content
- [ ] Responsive / media-query Custom CSS still works in editor and frontend

### Edge cases
- [ ] Block with no Custom CSS → no empty `<style>` tag rendered
- [ ] Multiple blocks with Custom CSS on one page → each keeps its own styles after Premium is off
- [ ] Design Library / existing content that already has `stk-custom-css` continues to render correctly on free