### PR TITLE
fix: increase the specificity of the stackable text alignment

### DIFF
--- a/src/styles/block.scss
+++ b/src/styles/block.scss
@@ -391,7 +391,10 @@
 }
 
 // Ensure that our alignments are applied to text.
-.stk-block {
+// WordPress introduces `:root .has-text-align-*` in version 7.0,
+// so we increase the specificity of our selectors to ensure that
+// our styles are applied correctly.
+.stk-block.stk-block {
 	&[class*="has-text-align-"],
 	[class*="has-text-align-"] {
 		text-align: var(--stk-alignment-text-align, start);


### PR DESCRIPTION
fixes #3736 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text alignment styling to ensure block alignment settings take precedence over WordPress 7.0 defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->