### PR TITLE
fix: allow align-items to be adjusted

### DIFF
--- a/src/block/hero/style.scss
+++ b/src/block/hero/style.scss
@@ -2,5 +2,5 @@
 
 .stk-block-hero__content > .stk-inner-blocks.stk--column-flex:not(.stk--block-horizontal-flex) {
 	justify-content: center;
-	align-items: center;
+	align-items: var(--stk-alignment-justify-content, center);
 }


### PR DESCRIPTION
fixes #3557 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Hero content alignment can now follow the configured justification setting, with centered alignment used as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->