### PR TITLE
test: add PHPUnit coverage for PHP runtime seams

### DIFF
--- a/.github/workflows/php-unit.yml
+++ b/.github/workflows/php-unit.yml
@@ -1,0 +1,43 @@
+name: PHP Unit
+
+on:
+  push:
+    branches: [ master, develop ]
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'phpunit.xml.dist'
+      - 'tests/phpunit/**'
+      - '.github/workflows/php-unit.yml'
+  pull_request:
+    branches: [ master, develop ]
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'phpunit.xml.dist'
+      - 'tests/phpunit/**'
+      - '.github/workflows/php-unit.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  phpunit:
+    name: PHPUnit PHP ${{ matrix.php_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php_version: [ '7.4', '8.5' ]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php_version }}
+          coverage: none
+          tools: composer:v2
+      - name: Install Composer dependencies
+        run: composer update --no-interaction --prefer-dist --no-progress
+      - name: Run PHPUnit
+        run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ test-results/**/trace.zip
 
 composer.phar
 composer.lock
+.phpunit.result.cache
 /vendor
 /wordpress
 /test-results/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ Do not apply GitHub changes (close, comment, relabel) during issue triage withou
 
 - Unit / Jest: `npm run test:unit` (wp-scripts / `@wordpress/jest-preset-default`). Watch: `npm run test:unit:watch`.
   Premium: `cd pro__premium_only && npm run test:unit` when `pro__premium_only/` is present.
+- PHP unit: `composer test` (PHPUnit 9 + Brain Monkey, no Docker / wp-env). Premium: `composer test:php:premium` when `pro__premium_only/` is present.
 - PHP compatibility: `composer phpcompat` (PHPCompatibilityWP; floor from `readme.txt` `Requires PHP`).
   Premium PHP: `composer phpcompat:premium` when `pro__premium_only/` is present.
 - Playwright e2e (WordPress Playground, no Docker): see [`e2e/readme.md`](./e2e/readme.md)

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -198,6 +198,27 @@ This is to prevent errors when upgrading Stackable.
 📝 Writing Tests
 =============
 
+### PHP unit tests
+
+PHP runtime tests live in `tests/phpunit/` (PHPUnit 9 + Brain Monkey). They do
+not boot WordPress, MySQL, or Freemius. Each test `require_once`s the PHP file
+under test after stubbing WordPress helpers.
+
+```bash
+composer test
+```
+
+Premium PHP tests live in `pro__premium_only/tests/phpunit/` and reuse the free
+Composer `vendor/` tree:
+
+```bash
+composer test:php:premium
+```
+
+Keep PHPUnit files under `tests/` so they are not packaged in the plugin zip.
+
+CI runs PHP 7.4 and 8.5 (same corners as Playwright).
+
 ### Block Testing
 
 Block testing is done in 5 steps, and covers the entirety of a block's codebase.

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,10 @@
 	"require-dev": {
 		"wp-cli/i18n-command": "^2.2",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-		"phpcompatibility/phpcompatibility-wp": "^2.1"
+		"phpcompatibility/phpcompatibility-wp": "^2.1",
+		"phpunit/phpunit": "^9.6",
+		"yoast/phpunit-polyfills": "^2.0",
+		"brain/monkey": "^2.6"
 	},
 	"config": {
 		"allow-plugins": {
@@ -15,6 +18,9 @@
 	},
 	"scripts": {
 		"phpcompat": "phpcs",
-		"phpcompat:premium": "phpcs --standard=pro__premium_only/phpcs.xml.dist pro__premium_only"
+		"phpcompat:premium": "phpcs --standard=pro__premium_only/phpcs.xml.dist pro__premium_only",
+		"test": "@test:php",
+		"test:php": "phpunit",
+		"test:php:premium": "php tests/phpunit/run-premium.php"
 	}
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,6 +10,7 @@
 	<exclude-pattern>*/dist/*</exclude-pattern>
 	<exclude-pattern>*/build/*</exclude-pattern>
 	<exclude-pattern>*/pro__premium_only/*</exclude-pattern>
+	<exclude-pattern>*/tests/*</exclude-pattern>
 
 	<arg name="extensions" value="php"/>
 	<arg name="basepath" value="."/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+	bootstrap="tests/phpunit/bootstrap.php"
+	colors="true"
+	beStrictAboutTestsThatDoNotTestAnything="true"
+	convertDeprecationsToExceptions="false"
+	>
+	<testsuites>
+		<testsuite name="free">
+			<directory suffix="Test.php">tests/phpunit</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/plugin.php
+++ b/plugin.php
@@ -251,6 +251,11 @@ if ( ! function_exists( 'is_frontend' ) ) {
 	}
 }
 
+// PHPUnit loads this file only for deactivation cleanup + is_frontend().
+if ( defined( 'STACKABLE_PHPUNIT' ) && STACKABLE_PHPUNIT ) {
+	return;
+}
+
 /**
  * Freemius.
  * This needs to be first.

--- a/tests/phpunit/BlockDefaultsSanitizeTest.php
+++ b/tests/phpunit/BlockDefaultsSanitizeTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Stored block-style sanitizers.
+ *
+ * @package Stackable
+ */
+
+use Brain\Monkey\Functions;
+
+class BlockDefaultsSanitizeTest extends Stackable_TestCase {
+
+	protected function set_up() {
+		parent::set_up();
+		Functions\when( 'wp_check_invalid_utf8' )->returnArg( 1 );
+		Functions\when( 'parse_blocks' )->justReturn( array() );
+		Functions\when( 'serialize_blocks' )->justReturn( '' );
+		$this->require_plugin_file( 'src/deprecated/block-defaults/custom-block-styles.php' );
+	}
+
+	private function styles() {
+		return new Stackable_Custom_Block_Styles();
+	}
+
+	public function test_sanitize_block_name_rejects_core_blocks() {
+		$styles = $this->styles();
+		$this->assertSame( '', $styles->sanitize_block_name( 'core/paragraph' ) );
+		$this->assertSame( 'stackable/heading', $styles->sanitize_block_name( 'stackable/heading' ) );
+	}
+
+	public function test_sanitize_style_slug_uses_sanitize_title() {
+		$this->assertSame( 'my-style', $this->styles()->sanitize_style_slug( 'My Style' ) );
+	}
+
+	public function test_sanitize_array_setting_rejects_non_array() {
+		$this->assertSame( array(), $this->styles()->sanitize_array_setting( 'nope' ) );
+	}
+
+	public function test_sanitize_stored_block_styles_drops_invalid_blocks() {
+		$styles = $this->styles();
+		$stored = array(
+			array(
+				'block' => 'core/paragraph',
+				'styles' => array(
+					array(
+						'slug' => 'plain',
+						'name' => 'Plain',
+						'data' => '{"attributes":{"text":"<script>x</script>"},"innerBlocks":[]}',
+						'save' => '',
+					),
+				),
+			),
+			array(
+				'block' => 'stackable/heading',
+				'styles' => array(
+					array(
+						'slug' => 'hero',
+						'name' => 'Hero',
+						'data' => '{"attributes":{"text":"Hello <script>x</script>"},"innerBlocks":[]}',
+						'save' => '',
+					),
+				),
+			),
+		);
+		$out = $styles->sanitize_stored_block_styles( $stored );
+		$this->assertCount( 1, $out );
+		$this->assertSame( 'stackable/heading', $out[0]->block );
+		$this->assertSame( 'hero', $out[0]->styles[0]->slug );
+		$this->assertStringNotContainsString( '<script>', $out[0]->styles[0]->data );
+	}
+}

--- a/tests/phpunit/CssOptimizeTest.php
+++ b/tests/phpunit/CssOptimizeTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Inline CSS optimizer: parse, skip dynamic, combine selectors.
+ *
+ * @package Stackable
+ */
+
+class CssOptimizeTest extends Stackable_TestCase {
+
+	protected function set_up() {
+		parent::set_up();
+		$this->require_plugin_file( 'src/css-optimize.php' );
+	}
+
+	public function test_parse_block_style_collects_css_by_unique_id() {
+		$styles = array();
+		Stackable_CSS_Optimize::parse_block_style(
+			array(
+				'innerHTML' => '<div><style>.stk-aaaaaaa{color:red}</style></div>',
+				'attrs' => array( 'uniqueId' => 'aaaaaaa' ),
+			),
+			$styles
+		);
+		$this->assertArrayHasKey( 'aaaaaaa', $styles );
+		$this->assertSame( '.stk-aaaaaaa{color:red}', $styles['aaaaaaa'][0][1] );
+	}
+
+	public function test_dynamic_style_is_not_collected() {
+		$styles = array();
+		Stackable_CSS_Optimize::parse_block_style(
+			array(
+				'innerHTML' => '<div><style>.stk-aaaaaaa{background:url(!#stk_dynamic/current-page/featured-image-data!#)}</style></div>',
+				'attrs' => array( 'uniqueId' => 'aaaaaaa' ),
+			),
+			$styles
+		);
+		$this->assertSame( array(), $styles );
+	}
+
+	public function test_generate_css_combines_matching_rules() {
+		$css = Stackable_CSS_Optimize::generate_css( array(
+			'.stk-aaaaaaa .child{color:red}',
+			'.stk-bbbbbbb .child{color:red}',
+		) );
+		$this->assertStringContainsString( ':is(.stk-aaaaaaa, .stk-bbbbbbb)', $css );
+		$this->assertStringContainsString( 'color:red', $css );
+	}
+
+	public function test_zero_px_is_left_in_generated_css() {
+		$css = Stackable_CSS_Optimize::generate_css( array(
+			'.stk-aaaaaaa{margin:0px}',
+		) );
+		$this->assertStringContainsString( '0px', $css );
+	}
+}

--- a/tests/phpunit/DeactivationCleanupTest.php
+++ b/tests/phpunit/DeactivationCleanupTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Deactivation deletes leftover options.
+ *
+ * @package Stackable
+ */
+
+use Brain\Monkey\Functions;
+
+class DeactivationCleanupTest extends Stackable_TestCase {
+
+	public function test_deactivation_deletes_cached_and_legacy_options() {
+		$deleted = array();
+		Functions\when( 'delete_option' )->alias( function( $name ) use ( &$deleted ) {
+			$deleted[] = $name;
+			return true;
+		} );
+
+		$this->require_plugin_file( 'plugin.php' );
+		$this->assertTrue( function_exists( 'stackable_deactivation_cleanup' ) );
+		stackable_deactivation_cleanup();
+
+		$this->assertEqualsCanonicalizing(
+			array(
+				'stackable_dynamic_content_other_fields_frontend',
+				'stackable_dynamic_content_meta_keys_frontend',
+				'stackable_inspector_premium_notice_status',
+				'stackable_enable_navigation_panel',
+				'stackable_custom_php_sigs',
+				'stackable_disp_cond_custom_php_sigs',
+			),
+			$deleted
+		);
+	}
+}

--- a/tests/phpunit/DesignLibraryValidateTest.php
+++ b/tests/phpunit/DesignLibraryValidateTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Design Library URL validation.
+ *
+ * @package Stackable
+ */
+
+use Brain\Monkey\Functions;
+
+class DesignLibraryValidateTest extends Stackable_TestCase {
+
+	protected function set_up() {
+		parent::set_up();
+		Functions\when( 'wp_http_validate_url' )->alias( function( $url ) {
+			if ( 0 === stripos( $url, 'javascript:' ) ) {
+				return false;
+			}
+			if ( ! preg_match( '#^https?://#i', $url ) ) {
+				return false;
+			}
+			return $url;
+		} );
+		$this->require_plugin_file( 'src/design-library/init.php' );
+	}
+
+	public function test_https_image_url_is_valid() {
+		$this->assertTrue(
+			Stackable_Design_Library::validate_url( 'https://example.com/a.png', null, 'image_url' )
+		);
+	}
+
+	public function test_javascript_url_is_rejected() {
+		$result = Stackable_Design_Library::validate_url( 'javascript:alert(1)', null, 'image_url' );
+		$this->assertInstanceOf( WP_Error::class, $result );
+	}
+
+	public function test_non_url_is_rejected() {
+		$result = Stackable_Design_Library::validate_url( 'not-a-url', null, 'image_url' );
+		$this->assertInstanceOf( WP_Error::class, $result );
+	}
+}

--- a/tests/phpunit/KsesTest.php
+++ b/tests/phpunit/KsesTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * KSES allowlist for Stackable SVG/style tags.
+ *
+ * @package Stackable
+ */
+
+use Brain\Monkey\Functions;
+
+class KsesTest extends Stackable_TestCase {
+
+	protected function set_up() {
+		parent::set_up();
+		$this->require_plugin_file( 'src/kses.php' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_missing_user_functions_leave_tags_unchanged() {
+		$tags = array( 'div' => array() );
+		$out = stackable_allow_wp_kses_allowed_html( $tags, 'post' );
+		$this->assertSame( $tags, $out );
+	}
+
+	public function test_user_without_edit_posts_leaves_tags_unchanged() {
+		Functions\when( 'wp_get_current_user' )->justReturn( (object) array( 'ID' => 2 ) );
+		Functions\when( 'current_user_can' )->justReturn( false );
+		$tags = array( 'div' => array() );
+		$out = stackable_allow_wp_kses_allowed_html( $tags, 'post' );
+		$this->assertSame( $tags, $out );
+		$this->assertArrayNotHasKey( 'svg', $out );
+	}
+
+	public function test_edit_posts_adds_svg_path_and_style() {
+		Functions\when( 'wp_get_current_user' )->justReturn( (object) array( 'ID' => 1 ) );
+		Functions\when( 'current_user_can' )->justReturn( true );
+		$tags = array( 'div' => array() );
+		$out = stackable_allow_wp_kses_allowed_html( $tags, 'post' );
+		$this->assertArrayHasKey( 'svg', $out );
+		$this->assertArrayHasKey( 'path', $out );
+		$this->assertArrayHasKey( 'style', $out );
+	}
+}

--- a/tests/phpunit/PostsExcerptTest.php
+++ b/tests/phpunit/PostsExcerptTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Posts excerpt: custom excerpt, trim, and tag stripping.
+ *
+ * @package Stackable
+ */
+
+use Brain\Monkey\Functions;
+
+class PostsExcerptTest extends Stackable_TestCase {
+
+	protected function set_up() {
+		parent::set_up();
+		$this->require_plugin_file( 'src/block/posts/index.php' );
+	}
+
+	public function test_custom_excerpt_is_used_when_present() {
+		Functions\when( 'get_post_field' )->alias( function( $field ) {
+			return 'post_excerpt' === $field ? 'Custom excerpt here' : '';
+		} );
+
+		$excerpt = Stackable_Posts_Block::get_excerpt_by_post_id( 1, array(), 55 );
+		$this->assertSame( 'Custom excerpt here', $excerpt );
+	}
+
+	public function test_content_is_trimmed_when_no_excerpt() {
+		Functions\when( 'get_post_field' )->justReturn( '' );
+		$words = implode( ' ', array_fill( 0, 20, 'word' ) );
+		$excerpt = Stackable_Posts_Block::get_excerpt_by_post_id( 1, array(
+			'post_content' => $words,
+		), 5 );
+		$this->assertLessThan( strlen( $words ), strlen( $excerpt ) );
+		$this->assertStringStartsWith( 'word word word word word', $excerpt );
+	}
+
+	public function test_anchor_tags_are_not_left_in_excerpt() {
+		Functions\when( 'get_post_field' )->justReturn( '' );
+		$excerpt = Stackable_Posts_Block::get_excerpt_by_post_id( 1, array(
+			'post_content' => '<a href="https://evil.example">click</a> more words here please',
+		), 10 );
+		$this->assertStringNotContainsString( '<a', $excerpt );
+	}
+
+	public function test_cjk_without_spaces_is_one_word_today() {
+		Functions\when( 'get_post_field' )->justReturn( '' );
+		$chinese = '这是一段没有空格的中文内容用于测试摘要长度';
+		$excerpt = Stackable_Posts_Block::get_excerpt_by_post_id( 1, array(
+			'post_content' => $chinese,
+		), 5 );
+		$this->assertSame( $chinese, $excerpt );
+	}
+}

--- a/tests/phpunit/PostsQueryTest.php
+++ b/tests/phpunit/PostsQueryTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Posts block WP_Query args from block attributes.
+ *
+ * @package Stackable
+ */
+
+class PostsQueryTest extends Stackable_TestCase {
+
+	protected function set_up() {
+		parent::set_up();
+		$this->require_plugin_file( 'src/block/posts/index.php' );
+	}
+
+	public function test_defaults_use_numberposts_not_posts_per_page() {
+		$query = generate_post_query_from_stackable_posts_block( array() );
+		$this->assertSame( 6, $query['numberposts'] );
+		$this->assertArrayNotHasKey( 'posts_per_page', $query );
+		$this->assertSame( 'date', $query['orderby'] );
+		$this->assertSame( 'desc', $query['order'] );
+		$this->assertSame( 'post', $query['post_type'] );
+	}
+
+	public function test_category_in_and_not_in() {
+		$in = generate_post_query_from_stackable_posts_block( array(
+			'taxonomyType' => 'category',
+			'taxonomy' => '3,7',
+			'taxonomyFilterType' => '__in',
+		) );
+		$this->assertSame( array( '3', '7' ), $in['category__in'] );
+
+		$not = generate_post_query_from_stackable_posts_block( array(
+			'taxonomyType' => 'category',
+			'taxonomy' => '3,7',
+			'taxonomyFilterType' => '__not_in',
+		) );
+		$this->assertSame( array( '3', '7' ), $not['category__not_in'] );
+	}
+
+	public function test_custom_taxonomy_operator() {
+		$in = generate_post_query_from_stackable_posts_block( array(
+			'taxonomyType' => 'product_cat',
+			'taxonomy' => '11,12',
+			'taxonomyFilterType' => '__in',
+		) );
+		$this->assertSame( 'IN', $in['tax_query'][0]['operator'] );
+		$this->assertSame( array( '11', '12' ), $in['tax_query'][0]['terms'] );
+
+		$not = generate_post_query_from_stackable_posts_block( array(
+			'taxonomyType' => 'product_cat',
+			'taxonomy' => '11',
+			'taxonomyFilterType' => '__not_in',
+		) );
+		$this->assertSame( 'NOT IN', $not['tax_query'][0]['operator'] );
+	}
+
+	public function test_two_category_filters_produce_different_queries() {
+		$a = generate_post_query_from_stackable_posts_block( array(
+			'taxonomyType' => 'category',
+			'taxonomy' => '1',
+			'taxonomyFilterType' => '__in',
+		) );
+		$b = generate_post_query_from_stackable_posts_block( array(
+			'taxonomyType' => 'category',
+			'taxonomy' => '2',
+			'taxonomyFilterType' => '__in',
+		) );
+		$this->assertNotSame( $a['category__in'], $b['category__in'] );
+	}
+}

--- a/tests/phpunit/PostsRenderTest.php
+++ b/tests/phpunit/PostsRenderTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Posts item markup: title escaping, untitled fallback, empty image.
+ *
+ * @package Stackable
+ */
+
+use Brain\Monkey\Functions;
+
+class PostsRenderTest extends Stackable_TestCase {
+
+	protected function set_up() {
+		parent::set_up();
+		$this->require_plugin_file( 'src/block/posts/index.php' );
+	}
+
+	private function attributes() {
+		return array(
+			'imageSize' => 'full',
+			'excerptLength' => 55,
+			'readmoreText' => 'Continue',
+			'metaSeparator' => 'dot',
+			'categoryHighlighted' => false,
+		);
+	}
+
+	public function test_script_in_title_is_escaped() {
+		Functions\when( 'get_the_post_thumbnail' )->justReturn( '' );
+		$html = generate_render_item_from_stackable_posts_block(
+			array(
+				'ID' => 1,
+				'post_title' => '<script>alert(1)</script>',
+			),
+			$this->attributes(),
+			'<h3>!#title!#</h3>'
+		);
+		$this->assertStringNotContainsString( '<script>', $html );
+		$this->assertStringContainsString( '&lt;script&gt;', $html );
+	}
+
+	public function test_empty_title_uses_untitled() {
+		Functions\when( 'get_the_post_thumbnail' )->justReturn( '' );
+		$html = generate_render_item_from_stackable_posts_block(
+			array(
+				'ID' => 1,
+				'post_title' => '',
+			),
+			$this->attributes(),
+			'<h3>!#title!#</h3>'
+		);
+		$this->assertStringContainsString( '(Untitled)', $html );
+	}
+
+	public function test_readmore_html_passes_through_kses() {
+		Functions\when( 'get_the_post_thumbnail' )->justReturn( '' );
+		$attrs = $this->attributes();
+		$attrs['readmoreText'] = 'Read <em>more</em><script>x</script>';
+		$html = generate_render_item_from_stackable_posts_block(
+			array(
+				'ID' => 1,
+				'post_title' => 'A',
+			),
+			$attrs,
+			'<a>!#readmoreText!#</a>'
+		);
+		$this->assertStringContainsString( '<em>more</em>', $html );
+		$this->assertStringNotContainsString( '<script>', $html );
+	}
+
+	public function test_missing_thumbnail_removes_figure() {
+		Functions\when( 'get_the_post_thumbnail' )->justReturn( '' );
+		$html = generate_render_item_from_stackable_posts_block(
+			array(
+				'ID' => 1,
+				'post_title' => 'A',
+			),
+			$this->attributes(),
+			'<figure class="stk"><img src="x" /></figure><h3>!#title!#</h3>'
+		);
+		$this->assertStringNotContainsString( '<figure', $html );
+		$this->assertStringContainsString( '<h3>A</h3>', $html );
+	}
+}

--- a/tests/phpunit/RestPermissionsTest.php
+++ b/tests/phpunit/RestPermissionsTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * REST permission callbacks for Posts, Design Library, and block styles.
+ *
+ * @package Stackable
+ */
+
+use Brain\Monkey\Functions;
+
+class RestPermissionsTest extends Stackable_TestCase {
+
+	public function test_posts_routes_require_edit_posts() {
+		$can = true;
+		Functions\when( 'current_user_can' )->alias( function() use ( &$can ) {
+			return $can;
+		} );
+
+		$this->require_plugin_file( 'src/block/posts/index.php' );
+		$posts = new Stackable_Posts_Block();
+		$posts->register_rest_fields();
+
+		$callback = $this->permission_callback_for( '/terms' );
+		$this->assertTrue( call_user_func( $callback ) );
+		$can = false;
+		$this->assertFalse( call_user_func( $callback ) );
+
+		$posts_callback = $this->permission_callback_for( '/get_posts' );
+		$can = true;
+		$this->assertTrue( call_user_func( $posts_callback ) );
+		$can = false;
+		$this->assertFalse( call_user_func( $posts_callback ) );
+	}
+
+	public function test_design_library_get_requires_edit_posts_and_image_requires_upload_files() {
+		$cap_allowed = 'edit_posts';
+		Functions\when( 'current_user_can' )->alias( function( $cap ) use ( &$cap_allowed ) {
+			return $cap === $cap_allowed;
+		} );
+
+		$this->require_plugin_file( 'src/design-library/init.php' );
+		$library = new Stackable_Design_Library();
+		$library->register_route();
+
+		$get = $this->route_containing( 'design_library/' );
+		$post = $this->route_containing( 'design_library_image' );
+
+		$this->assertTrue( call_user_func( $get['permission_callback'] ) );
+		$this->assertFalse( call_user_func( $post['permission_callback'] ) );
+
+		$cap_allowed = 'upload_files';
+		$this->assertFalse( call_user_func( $get['permission_callback'] ) );
+		$this->assertTrue( call_user_func( $post['permission_callback'] ) );
+	}
+
+	public function test_block_styles_require_edit_theme_options() {
+		$this->require_plugin_file( 'src/deprecated/block-defaults/custom-block-styles.php' );
+		Functions\when( 'current_user_can' )->alias( function( $cap ) {
+			return 'edit_theme_options' === $cap;
+		} );
+		$this->assertTrue( Stackable_Custom_Block_Styles::can_manage_block_styles() );
+
+		Functions\when( 'current_user_can' )->justReturn( false );
+		$this->assertFalse( Stackable_Custom_Block_Styles::can_manage_block_styles() );
+	}
+
+	/**
+	 * @param string $needle
+	 * @return callable
+	 */
+	private function permission_callback_for( $needle ) {
+		$route = $this->route_containing( $needle );
+		return $route['permission_callback'];
+	}
+
+	/**
+	 * @param string $needle
+	 * @return array
+	 */
+	private function route_containing( $needle ) {
+		$routes = isset( $GLOBALS['stackable_phpunit_rest_routes'] ) ? $GLOBALS['stackable_phpunit_rest_routes'] : array();
+		foreach ( $routes as $route ) {
+			if ( isset( $route['_route'] ) && false !== strpos( $route['_route'], $needle ) ) {
+				return $route;
+			}
+		}
+		$this->fail( 'Route not registered: ' . $needle );
+	}
+}

--- a/tests/phpunit/SvgSanitizeTest.php
+++ b/tests/phpunit/SvgSanitizeTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Custom SVG setting sanitizer.
+ *
+ * @package Stackable
+ */
+
+class SvgSanitizeTest extends Stackable_TestCase {
+
+	protected function set_up() {
+		parent::set_up();
+		$this->require_plugin_file( 'src/editor-settings.php' );
+	}
+
+	private function sanitizer() {
+		$settings = new Stackable_Editor_Settings();
+		return $settings;
+	}
+
+	public function test_empty_returns_empty_string() {
+		$this->assertSame( '', $this->sanitizer()->sanitize_svg_setting( '' ) );
+	}
+
+	public function test_strips_script_onclick_and_javascript_urls() {
+		$input = '<svg><script>alert(1)</script><path onclick="alert(1)" d="M0 0"/><a href="javascript:alert(1)"/></svg>';
+		$out = $this->sanitizer()->sanitize_svg_setting( $input );
+		$this->assertStringNotContainsString( '<script>', $out );
+		$this->assertStringNotContainsString( 'onclick', $out );
+		$this->assertStringNotContainsString( 'javascript:', $out );
+		$this->assertStringContainsString( '<path', $out );
+	}
+
+	public function test_harmless_path_remains() {
+		$input = '<svg xmlns="http://www.w3.org/2000/svg"><path d="M10 10h10"/></svg>';
+		$out = $this->sanitizer()->sanitize_svg_setting( $input );
+		$this->assertStringContainsString( '<path d="M10 10h10"/>', $out );
+	}
+}

--- a/tests/phpunit/TestCase.php
+++ b/tests/phpunit/TestCase.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Base PHPUnit case: Brain Monkey + common WordPress stubs.
+ *
+ * @package Stackable
+ */
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase as PolyfillTestCase;
+
+abstract class Stackable_TestCase extends PolyfillTestCase {
+
+	/**
+	 * Closures registered via add_filter() during a test.
+	 *
+	 * @var array
+	 */
+	protected $captured_filters = array();
+
+	protected function set_up() {
+		parent::set_up();
+		Monkey\setUp();
+		$GLOBALS['stackable_phpunit_rest_routes'] = array();
+		$this->captured_filters = array();
+		$this->stub_wordpress_defaults();
+	}
+
+	protected function tear_down() {
+		unset( $GLOBALS['stackable_unique_ids'] );
+		Monkey\tearDown();
+		parent::tear_down();
+	}
+
+	/**
+	 * Stub WordPress helpers used at file-load and in the PHP seams under test.
+	 * add_filter / apply_filters run captured closures (Brain Monkey does not).
+	 * Leave add_action / do_action to Brain Monkey.
+	 */
+	protected function stub_wordpress_defaults() {
+		Functions\when( '__' )->returnArg( 1 );
+		Functions\when( 'esc_html__' )->returnArg( 1 );
+		Functions\when( 'esc_html' )->alias( array( $this, 'stub_esc_html' ) );
+		Functions\when( 'esc_attr' )->alias( array( $this, 'stub_esc_html' ) );
+		Functions\when( 'esc_url' )->returnArg( 1 );
+		Functions\when( 'esc_url_raw' )->returnArg( 1 );
+		Functions\when( 'wp_kses_post' )->alias( array( $this, 'stub_wp_kses_post' ) );
+		Functions\when( 'sanitize_text_field' )->alias( array( $this, 'stub_sanitize_text_field' ) );
+		Functions\when( 'sanitize_title' )->alias( array( $this, 'stub_sanitize_title' ) );
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+		Functions\when( 'wp_trim_words' )->alias( array( $this, 'stub_wp_trim_words' ) );
+		Functions\when( 'is_admin' )->justReturn( true );
+		Functions\when( 'wp_is_json_request' )->justReturn( false );
+		Functions\when( 'get_option' )->justReturn( false );
+		Functions\when( 'register_activation_hook' )->justReturn( true );
+		Functions\when( 'register_deactivation_hook' )->justReturn( true );
+		Functions\when( 'add_option' )->justReturn( true );
+		Functions\when( 'register_setting' )->justReturn( true );
+
+		$that = $this;
+		Functions\when( 'add_filter' )->alias( function( $tag, $fn, $priority = 10, $accepted_args = 1 ) use ( $that ) {
+			if ( ! isset( $that->captured_filters[ $tag ] ) ) {
+				$that->captured_filters[ $tag ] = array();
+			}
+			$that->captured_filters[ $tag ][] = $fn;
+			return true;
+		} );
+		Functions\when( 'apply_filters' )->alias( function( $tag, $value ) use ( $that ) {
+			$args = func_get_args();
+			array_shift( $args );
+			if ( empty( $that->captured_filters[ $tag ] ) ) {
+				return $value;
+			}
+			foreach ( $that->captured_filters[ $tag ] as $fn ) {
+				$value = call_user_func_array( $fn, $args );
+				$args[0] = $value;
+			}
+			return $value;
+		} );
+	}
+
+	/**
+	 * Require a production file relative to the free plugin root.
+	 *
+	 * @param string $relative Path from plugin root.
+	 */
+	protected function require_plugin_file( $relative ) {
+		require_once STACKABLE_PLUGIN_DIR . ltrim( $relative, '/' );
+	}
+
+	/**
+	 * Require a production file relative to pro__premium_only/.
+	 *
+	 * @param string $relative Path from the premium directory.
+	 */
+	protected function require_premium_file( $relative ) {
+		if ( ! defined( 'STACKABLE_PREMIUM_DIR' ) ) {
+			$this->markTestSkipped( 'pro__premium_only is not present' );
+		}
+		require_once STACKABLE_PREMIUM_DIR . '/' . ltrim( $relative, '/' );
+	}
+
+	/**
+	 * Include a premium file every test (for files that register closures at load time).
+	 *
+	 * @param string $relative Path from the premium directory.
+	 */
+	protected function include_premium_file( $relative ) {
+		if ( ! defined( 'STACKABLE_PREMIUM_DIR' ) ) {
+			$this->markTestSkipped( 'pro__premium_only is not present' );
+		}
+		include STACKABLE_PREMIUM_DIR . '/' . ltrim( $relative, '/' );
+	}
+
+	public function stub_esc_html( $text ) {
+		return htmlspecialchars( (string) $text, ENT_QUOTES, 'UTF-8' );
+	}
+
+	public function stub_wp_kses_post( $text ) {
+		return preg_replace( '#<script\b[^>]*>.*?</script>#is', '', (string) $text );
+	}
+
+	public function stub_sanitize_text_field( $value ) {
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
+		return trim( strip_tags( $value ) );
+	}
+
+	public function stub_sanitize_title( $value ) {
+		$value = strtolower( (string) $value );
+		$value = preg_replace( '/[^a-z0-9]+/', '-', $value );
+		return trim( $value, '-' );
+	}
+
+	/**
+	 * WordPress-like trim: strip tags, then split on whitespace.
+	 *
+	 * @param string $text
+	 * @param int    $num_words
+	 * @param string|null $more
+	 * @return string
+	 */
+	public function stub_wp_trim_words( $text, $num_words = 55, $more = null ) {
+		if ( null === $more ) {
+			$more = '&hellip;';
+		}
+		$text = preg_replace( '/<[^>]*>/', '', (string) $text );
+		$words = preg_split( '/[\r\n\t ]+/', trim( $text ), $num_words + 1 );
+		if ( false === $words ) {
+			return '';
+		}
+		if ( count( $words ) > $num_words ) {
+			array_pop( $words );
+			return implode( ' ', $words ) . $more;
+		}
+		return implode( ' ', $words );
+	}
+}

--- a/tests/phpunit/UniqueIdTest.php
+++ b/tests/phpunit/UniqueIdTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Duplicate uniqueId rewrite on the frontend.
+ *
+ * @package Stackable
+ */
+
+class UniqueIdTest extends Stackable_TestCase {
+
+	protected function set_up() {
+		parent::set_up();
+		$this->require_plugin_file( 'src/unique-id.php' );
+		$GLOBALS['stackable_unique_ids'] = array();
+	}
+
+	public function test_non_stackable_block_is_unchanged() {
+		$html = '<p class="stk-abc1234">Hello</p>';
+		$out = stackable_prevent_duplicate_unique_ids( $html, array(
+			'blockName' => 'core/paragraph',
+			'attrs' => array( 'uniqueId' => 'abc1234' ),
+		) );
+		$this->assertSame( $html, $out );
+	}
+
+	public function test_missing_attrs_is_unchanged() {
+		$html = '<div class="stk-abc1234"></div>';
+		$out = stackable_prevent_duplicate_unique_ids( $html, array(
+			'blockName' => 'stackable/heading',
+		) );
+		$this->assertSame( $html, $out );
+	}
+
+	public function test_empty_unique_id_is_unchanged() {
+		$html = '<div class="stk-block"></div>';
+		$out = stackable_prevent_duplicate_unique_ids( $html, array(
+			'blockName' => 'stackable/heading',
+			'attrs' => array( 'uniqueId' => '' ),
+		) );
+		$this->assertSame( $html, $out );
+	}
+
+	public function test_first_unique_id_is_kept() {
+		$html = '<h2 class="stk-abc1234" data-block-id="abc1234">Title</h2>';
+		$block = array(
+			'blockName' => 'stackable/heading',
+			'attrs' => array( 'uniqueId' => 'abc1234' ),
+		);
+		$out = stackable_prevent_duplicate_unique_ids( $html, $block );
+		$this->assertSame( $html, $out );
+	}
+
+	public function test_duplicate_unique_id_is_rewritten() {
+		$html = '<h2 class="stk-abc1234" data-block-id="abc1234">Title</h2>';
+		$block = array(
+			'blockName' => 'stackable/heading',
+			'attrs' => array( 'uniqueId' => 'abc1234' ),
+		);
+
+		stackable_prevent_duplicate_unique_ids( $html, $block );
+		$second = stackable_prevent_duplicate_unique_ids( $html, $block );
+
+		$this->assertStringNotContainsString( 'abc1234', $second );
+		$this->assertMatchesRegularExpression( '/stk-[0-9a-z]{7}/', $second );
+		$this->assertMatchesRegularExpression( '/data-block-id="[0-9a-z]{7}"/', $second );
+
+		$third = stackable_prevent_duplicate_unique_ids( $html, $block );
+		$this->assertStringNotContainsString( 'abc1234', $third );
+		$this->assertNotSame( $second, $third );
+	}
+}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * PHPUnit bootstrap for Stackable PHP runtime tests.
+ *
+ * Does not load plugin.php or Freemius. Each test require_once()s the
+ * production file under test after Brain Monkey is set up.
+ *
+ * @package Stackable
+ */
+
+$stackable_root = dirname( __DIR__, 2 );
+
+require_once $stackable_root . '/vendor/autoload.php';
+
+if ( class_exists( '\Yoast\PHPUnitPolyfills\Autoload' ) ) {
+	// Polyfills are autoloaded via Composer.
+}
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', $stackable_root . '/tests/phpunit/abspath/' );
+}
+
+if ( ! defined( 'STACKABLE_PHPUNIT' ) ) {
+	define( 'STACKABLE_PHPUNIT', true );
+}
+
+if ( ! defined( 'STACKABLE_FILE' ) ) {
+	define( 'STACKABLE_FILE', $stackable_root . '/plugin.php' );
+}
+
+if ( ! defined( 'STACKABLE_VERSION' ) ) {
+	define( 'STACKABLE_VERSION', '0.0.0-test' );
+}
+
+if ( ! defined( 'STACKABLE_I18N' ) ) {
+	define( 'STACKABLE_I18N', 'stackable-ultimate-gutenberg-blocks' );
+}
+
+if ( ! defined( 'STACKABLE_BUILD' ) ) {
+	define( 'STACKABLE_BUILD', 'free' );
+}
+
+if ( ! defined( 'STACKABLE_PLUGIN_DIR' ) ) {
+	define( 'STACKABLE_PLUGIN_DIR', $stackable_root . '/' );
+}
+
+$premium_dir = $stackable_root . '/pro__premium_only';
+if ( is_dir( $premium_dir ) && ! defined( 'STACKABLE_PREMIUM_DIR' ) ) {
+	define( 'STACKABLE_PREMIUM_DIR', $premium_dir );
+}
+
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		public $errors = array();
+		public $error_data = array();
+		public $code = '';
+		public $message = '';
+
+		public function __construct( $code = '', $message = '', $data = '' ) {
+			$this->code = $code;
+			$this->message = $message;
+			if ( $code ) {
+				$this->errors[ $code ][] = $message;
+			}
+			if ( $data ) {
+				$this->error_data[ $code ] = $data;
+			}
+		}
+
+		public function get_error_code() {
+			return $this->code;
+		}
+
+		public function get_error_message() {
+			return $this->message;
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'is_frontend' ) ) {
+	function is_frontend() {
+		return false;
+	}
+}
+
+if ( ! function_exists( '__return_false' ) ) {
+	function __return_false() {
+		return false;
+	}
+}
+
+if ( ! function_exists( '__return_true' ) ) {
+	function __return_true() {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'register_rest_route' ) ) {
+	function register_rest_route( $namespace, $route, $args = array() ) {
+		$args['_route'] = $route;
+		$args['_namespace'] = $namespace;
+		$GLOBALS['stackable_phpunit_rest_routes'][] = $args;
+		return true;
+	}
+}
+
+require_once __DIR__ . '/TestCase.php';

--- a/tests/phpunit/run-premium.php
+++ b/tests/phpunit/run-premium.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Run the premium PHPUnit suite when pro__premium_only/ is present.
+ *
+ * @package Stackable
+ */
+
+$root = dirname( __DIR__, 2 );
+$premium = $root . '/pro__premium_only';
+
+if ( ! is_dir( $premium ) ) {
+	fwrite( STDOUT, "Skipping premium PHPUnit (pro__premium_only missing)\n" );
+	exit( 0 );
+}
+
+$phpunit = $root . '/vendor/bin/phpunit';
+$config = $premium . '/phpunit.xml.dist';
+
+passthru(
+	escapeshellarg( $phpunit ) . ' -c ' . escapeshellarg( $config ),
+	$code
+);
+exit( $code );


### PR DESCRIPTION
## Summary
- Adds a PHPUnit 9 + Brain Monkey harness (no Docker / wp-env) for PHP runtime seams in the free plugin.
- Covers unique IDs, Posts query/render/excerpt, KSES, SVG sanitization, CSS optimize, REST permissions, Design Library validation, block defaults, and deactivation cleanup.
- CI runs `composer test` on PHP 7.4 and 8.5. Pair with the matching premium PR on branch `test/phpunit-runtime`.

## Test plan
- [ ] `composer test` passes locally
- [ ] GitHub Action `PHPUnit` is green on PHP 7.4 and 8.5
- [ ] Confirm `tests/` is not included in the WordPress.org zip (gulp `buildInclude` whitelist)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated PHP unit testing for core functionality, including content rendering, sanitization, REST permissions, queries, and cleanup.
  * Added support for running standard and premium test suites.

* **Documentation**
  * Added PHP testing guidance, commands, coverage details, and CI version information.

* **Chores**
  * Added automated test checks for supported PHP versions on relevant changes.
  * Improved test isolation and ignored PHPUnit result files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->