### PR TITLE
fix(editor): prevent images collapsing in flex layouts

### DIFF
--- a/src/block-components/image/editor.scss
+++ b/src/block-components/image/editor.scss
@@ -89,6 +89,7 @@
 	position: absolute;
 	inset: 0;
 	pointer-events: none;
+
 	// Keep the tooltip above the click-to-edit overlay at z-index 2.
 	z-index: 3;
 	container-name: stk-img-resizer-tooltip;

--- a/src/block-components/image/editor.scss
+++ b/src/block-components/image/editor.scss
@@ -85,11 +85,19 @@
 }
 
 // Hide the size tooltip when the image resizer is too narrow.
-.stk-img-resizer {
+.stk-img-resizer-tooltip-container {
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	container-name: stk-img-resizer-tooltip;
 	container-type: inline-size;
+
+	.stk-resizer-tooltip {
+		pointer-events: auto;
+	}
 }
 
-@container (max-width: 139px) {
+@container stk-img-resizer-tooltip (max-width: 139px) {
 	.stk-resizer-tooltip {
 		display: none !important;
 	}

--- a/src/block-components/image/editor.scss
+++ b/src/block-components/image/editor.scss
@@ -89,6 +89,8 @@
 	position: absolute;
 	inset: 0;
 	pointer-events: none;
+	// Keep the tooltip above the click-to-edit overlay at z-index 2.
+	z-index: 3;
 	container-name: stk-img-resizer-tooltip;
 	container-type: inline-size;
 

--- a/src/block-components/image/image.js
+++ b/src/block-components/image/image.js
@@ -218,39 +218,41 @@ const Image = memo( props => {
 				</button>
 			) }
 			{ props.hasTooltip && props.showTooltips && (
-				<ResizerTooltip
-					enableHeight={ props.enableHeight || props.enableDiagonal }
-					enableWidth={ props.enableWidth || props.enableDiagonal }
-					height={ formSize( currentHeight || props.height, props.heightUnit, false, false ) }
-					width={ formSize( currentWidth || props.width, props.widthUnit, false, false ) }
-					widthUnits={ props.widthUnits }
-					heightUnits={ props.heightUnits }
-					heightUnit={ props.heightUnit }
-					widthUnit={ props.widthUnit }
-					allowReset={ props.allowReset }
-					defaultWidth={ props.defaultWidth }
-					defaultHeight={ props.defaultHeight }
-					onChangeHeight={ ( { value, unit } ) => {
-						const size = {}
-						if ( typeof value !== 'undefined' ) {
-							size.height = value
-						}
-						if ( typeof unit !== 'undefined' ) {
-							size.heightUnit = unit
-						}
-						props.onChangeSize( size )
-					} }
-					onChangeWidth={ ( { value, unit } ) => {
-						const size = {}
-						if ( typeof value !== 'undefined' ) {
-							size.width = value
-						}
-						if ( typeof unit !== 'undefined' ) {
-							size.widthUnit = unit
-						}
-						props.onChangeSize( size )
-					} }
-				/>
+				<div className="stk-img-resizer-tooltip-container">
+					<ResizerTooltip
+						enableHeight={ props.enableHeight || props.enableDiagonal }
+						enableWidth={ props.enableWidth || props.enableDiagonal }
+						height={ formSize( currentHeight || props.height, props.heightUnit, false, false ) }
+						width={ formSize( currentWidth || props.width, props.widthUnit, false, false ) }
+						widthUnits={ props.widthUnits }
+						heightUnits={ props.heightUnits }
+						heightUnit={ props.heightUnit }
+						widthUnit={ props.widthUnit }
+						allowReset={ props.allowReset }
+						defaultWidth={ props.defaultWidth }
+						defaultHeight={ props.defaultHeight }
+						onChangeHeight={ ( { value, unit } ) => {
+							const size = {}
+							if ( typeof value !== 'undefined' ) {
+								size.height = value
+							}
+							if ( typeof unit !== 'undefined' ) {
+								size.heightUnit = unit
+							}
+							props.onChangeSize( size )
+						} }
+						onChangeWidth={ ( { value, unit } ) => {
+							const size = {}
+							if ( typeof value !== 'undefined' ) {
+								size.width = value
+							}
+							if ( typeof unit !== 'undefined' ) {
+								size.widthUnit = unit
+							}
+							props.onChangeSize( size )
+						} }
+					/>
+				</div>
 			) }
 			<div className="stk-img-resizer-wrapper" ref={ wrapperRef }>
 				<img

--- a/src/components/resizer-tooltip/index.js
+++ b/src/components/resizer-tooltip/index.js
@@ -162,7 +162,7 @@ const ResizerTooltip = props => {
 				setPrevSwitchedHeight( props.height )
 				// At first switch, remember the height
 				// Calculate new height based on the current one
-				const imgEl = tooltipRef.current?.parentElement.querySelector( '.stk-img' )
+				const imgEl = tooltipRef.current?.closest( '.stk-img-resizer' )?.querySelector( '.stk-img' )
 				const newSize = convertSizeByUnit( props.height, unit, 'height', imgEl )
 				setCurrentHeight( newSize )
 				height = clampSize( newSize, unit )

--- a/src/components/resizer-tooltip/index.js
+++ b/src/components/resizer-tooltip/index.js
@@ -109,7 +109,7 @@ const ResizerTooltip = props => {
 				setPrevSwitchedWidth( props.width )
 				// At first switch, remember the width
 				// Calculate new width based on the current one
-				const imgEl = tooltipRef.current?.parentElement.querySelector( '.stk-img' )
+				const imgEl = tooltipRef.current?.closest( '.stk-img-resizer' )?.querySelector( '.stk-img' )
 				const newSize = convertSizeByUnit( props.width, unit, 'width', imgEl )
 				setCurrentWidth( newSize )
 				width = clampSize( newSize, unit )


### PR DESCRIPTION
The Image blocks inside an Inner Column collapses to zero width in the editor after changing Inner Block Direction or Inner Block Justify.

This was caused by `container-type: inline-size` being applied directly to the image resizer. In flex layouts that rely on intrinsic sizing, containment prevented the image from contributing its natural width. 


### Fix:

Move inline-size containment to a dedicated absolute tooltip overlay. The overlay still measures the image width and hides the size tooltip on narrow images, but it no longer participates in the image layout.

This preserves the Safari performance optimization while preventing images from collapsing in horizontal or justified Inner Column layouts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the image resizing tooltip’s positioning across different layouts and container sizes.
  * Fixed width and height unit switching so controls consistently apply to the associated image.
  * Enhanced tooltip interaction handling so resizing controls remain accessible without obstructing other image interactions.
  * Improved tooltip visibility in narrow containers, keeping the interface clear when there is insufficient space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->