### PR TITLE
fix: add small padding to make the outline inside the control

### DIFF
--- a/src/components/columns-width-control/editor.scss
+++ b/src/components/columns-width-control/editor.scss
@@ -3,7 +3,8 @@
 		margin-bottom: 0;
 	}
 	.ugb-design-control {
-		padding: 0;
+		// Keep the outlines inside the control.
+		padding-inline: 2px;
 		.components-radio-control__option {
 			width: 25%;
 		}


### PR DESCRIPTION
fixes #3385 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted design control spacing to improve visual alignment.
  * Kept control outlines neatly within their boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->