### PR TITLE
Fixed WordPress minimum required version number to 6.9

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -258,7 +258,7 @@ Add animations that will bring your site to life and make it more visually engag
 
 = Minimum Requirements =
 
-You'll need WordPress version 6.8.1 or higher for this to work.
+You'll need WordPress version 6.9 or higher for this to work.
 
 == Frequently Asked Questions ==
 


### PR DESCRIPTION
Hello @bfintal

Fixed WordPress minimum required version number to 6.9

Thanks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the minimum required WordPress version to 6.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->