### PR TITLE
feat: use a direct URL input in Stackable link controls

### DIFF
--- a/src/components/link-control/editor.scss
+++ b/src/components/link-control/editor.scss
@@ -1,6 +1,7 @@
 .stk-link-control__input {
 	// Adjust width to ensure reset button is visible.
 	width: calc(100% - 32px);
+	min-width: 0;
 
 	> .block-editor-link-control {
 		min-width: auto;
@@ -27,6 +28,20 @@
 			white-space: nowrap;
 		}
 
+	}
+
+	> .block-editor-url-input {
+		min-width: 0;
+		width: 100%;
+
+		.components-base-control {
+			min-width: 0;
+			width: 100%;
+		}
+
+		.components-base-control__field {
+			margin: 0;
+		}
 	}
 
 	.block-editor-url-input__input {

--- a/src/components/link-control/index.js
+++ b/src/components/link-control/index.js
@@ -1,12 +1,14 @@
 /**
  * External dependencies
  */
+import { settings } from 'stackable'
 import classnames from 'classnames'
 
 /**
  * WordPress dependencies
  */
 import {
+	URLInput,
 	__experimentalLinkControl as _LinkControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/block-editor'
 import { BaseControl as _BaseControl } from '@wordpress/components'
@@ -25,6 +27,7 @@ const LinkControl = props => {
 	const [ propsToPass, controlProps ] = extractControlProps( props )
 	const {
 		isDynamic,
+		showSuggestions,
 		...inputProps
 	} = propsToPass
 
@@ -32,6 +35,8 @@ const LinkControl = props => {
 	const onChange = typeof props.onChange === 'undefined' ? _onChange : props.onChange
 
 	const dynamicContentProps = useDynamicContentControlProps( { value, onChange } )
+
+	const useUnrestrictedURLInput = !! settings.stackable_enable_unrestricted_url_input
 
 	const classNames = classnames( [
 		'stk-link-control',
@@ -48,13 +53,22 @@ const LinkControl = props => {
 				{ ...dynamicContentProps }
 			>
 				<div className="stk-link-control__input">
-					<_LinkControl
-						{ ...inputProps }
-						value={ { url: value } }
-						onChange={ ( { url } ) => onChange( url ) }
-						settings={ [] } // The Url only.
-						forceIsEditingLink={ ! value }
-					/>
+					{ useUnrestrictedURLInput ? (
+						<URLInput
+							{ ...inputProps }
+							value={ value }
+							onChange={ onChange }
+							disableSuggestions={ ! showSuggestions }
+						/>
+					) : (
+						<_LinkControl
+							{ ...inputProps }
+							value={ { url: value } }
+							onChange={ ( { url } ) => onChange( url ) }
+							settings={ [] } // The Url only.
+							forceIsEditingLink={ ! value }
+						/>
+					) }
 				</div>
 			</DynamicContentControl>
 			<ResetButton

--- a/src/editor-settings.php
+++ b/src/editor-settings.php
@@ -161,6 +161,18 @@ if ( ! class_exists( 'Stackable_Editor_Settings' ) ) {
 
 			register_setting(
 				'stackable_editor_settings',
+				'stackable_enable_unrestricted_url_input',
+				array(
+					'type' => 'boolean',
+					'description' => __( 'Uses the legacy URL input in Stackable link controls, allowing shortcodes and other dynamic URL values.', STACKABLE_I18N ),
+					'sanitize_callback' => 'rest_sanitize_boolean',
+					'show_in_rest' => true,
+					'default' => false,
+				)
+			);
+
+			register_setting(
+				'stackable_editor_settings',
 				'stackable_help_tooltip_disabled',
 				array(
 					'type' => 'string',
@@ -311,6 +323,7 @@ if ( ! class_exists( 'Stackable_Editor_Settings' ) ) {
 			$settings['stackable_auto_collapse_panels'] = get_option( 'stackable_auto_collapse_panels' );
 			$settings['stackable_enable_global_settings'] = get_option( 'stackable_enable_global_settings' );
 			$settings['stackable_enable_block_linking'] = get_option( 'stackable_enable_block_linking' );
+			$settings['stackable_enable_unrestricted_url_input'] = get_option( 'stackable_enable_unrestricted_url_input' );
 			$settings['stackable_enable_text_highlight'] = get_option( 'stackable_enable_text_highlight' );
 			$settings['stackable_enable_dynamic_content'] = get_option( 'stackable_enable_dynamic_content' );
 			$settings['stackable_enable_copy_paste_styles'] = get_option( 'stackable_enable_copy_paste_styles' );

--- a/src/welcome/admin.js
+++ b/src/welcome/admin.js
@@ -99,6 +99,7 @@ const SEARCH_TREE = [
 					__( 'Stackable Settings', i18n ),
 					__( 'Use Size Presets by Default', i18n ),
 					__( 'Block Linking (Beta)', i18n ),
+					__( 'Use Unrestricted URL Input', i18n ),
 				],
 			},
 			{
@@ -787,6 +788,17 @@ const EditorSettings = props => {
 										<a target="_docs" href="https://docs.wpstackable.com/article/452-how-to-use-block-linking">{ __( 'Learn more', i18n ) }</a>
 									</>
 								}
+							/>
+							<AdminToggleSetting
+								label={ __( 'Use Unrestricted URL Input', i18n ) }
+								searchedSettings={ editor.children }
+								value={ settings.stackable_enable_unrestricted_url_input }
+								onChange={ value => {
+									handleSettingsChange( { stackable_enable_unrestricted_url_input: value } ) // eslint-disable-line camelcase
+								} }
+								help={ __( 'Uses the legacy URL field in all Stackable link controls. Enable this for shortcodes, template tokens, or other dynamic URL values. This disables Gutenberg URL validation.', i18n ) }
+								disabled={ __( 'Use Gutenberg URL input', i18n ) }
+								enabled={ __( 'Use unrestricted URL input', i18n ) }
 							/>
 						</div>
 					}


### PR DESCRIPTION
## Summary
- Replaces Gutenberg's `LinkControl` in Stackable link fields with the direct URL input.
- Validates URL-like values (and prepends `https://` to bare domains on blur).
- Still accepts shortcodes, dynamic content tokens, and other non-URL values that Gutenberg's LinkControl now rejects.
- Removes the Editor Settings toggle from the original approach. This is the default behavior for all Stackable link fields.

## Test plan
- [ ] Insert a Button, open Style > Link, type `https://example.com` and confirm it saves.
- [ ] Type `example.com` and leave the field. It should become `https://example.com`.
- [ ] Type an invalid URL like `https://` and confirm the "Please enter a valid URL." error is shown.
- [ ] Type a shortcode like `[my_link]` and confirm it saves with no error.
- [ ] Insert dynamic content into the link field and confirm it saves.
- [ ] Type an anchor (`#section`) and a relative path (`/about`) and confirm they save.
- [ ] Confirm there is no "Use Unrestricted URL Input" setting under Stackable Settings > Editor Settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added link validation with a localized error message for invalid URLs.
  * Supports domains, relative paths, hash links, shortcodes, dynamic tags, and placeholders.
  * Automatically normalizes valid bare domains by adding `https://`.

* **Bug Fixes**
  * Improved link input sizing so fields use available space more reliably.
  * Simplified link control styling for more consistent spacing and layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->